### PR TITLE
Potential fix for code scanning alert no. 1: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,8 @@
     "pino-http": "^11.0.0",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^13.0.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "csurf": "^1.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -16,6 +16,7 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import csurf from 'csurf';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -59,6 +60,10 @@ app.use(express.json({
     }
 })); // Increase limit for large SRS data
 app.use(cookieParser());
+
+const csrfProtection = csurf({ cookie: true });
+app.use(csrfProtection);
+
 app.use(logger);
 
 // Root health check
@@ -67,6 +72,11 @@ app.get('/', (req, res) => {
 });
 
 app.get('/favicon.ico', (req, res) => res.status(204).end());
+
+// Endpoint to retrieve CSRF token for clients that need it
+app.get('/csrf-token', (req, res) => {
+    res.json({ csrfToken: req.csrfToken() });
+});
 
 // Swagger API Documentation
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));


### PR DESCRIPTION
Potential fix for [https://github.com/Aniket-a14/SRA/security/code-scanning/1](https://github.com/Aniket-a14/SRA/security/code-scanning/1)

In general, to fix this issue you need to add CSRF protection middleware into the Express middleware chain after cookies and body are parsed but before any state-changing or authenticated routes are registered. A standard approach is to use a well-known library such as `csurf` (or `lusca.csrf`) that generates a per-session token and validates it on incoming modifying requests. The token is then made available to the frontend (via JSON or template locals) so that each POST/PUT/PATCH/DELETE request includes it (e.g., as a header or in the body).

For this specific file, the least invasive fix is to: (1) import a CSRF middleware such as `csurf`; (2) configure and register it right after `cookieParser()` and before the routes (`authRoutes`, `analysisRoutes`, etc.); and (3) if needed, expose the token with a lightweight handler for clients that need to fetch it. We must not change existing behavior of routes or change imports other than adding a new one. A sound default is:

- Add `import csurf from 'csurf';` at the top.
- Create a CSRF protection middleware `const csrfProtection = csurf({ cookie: true });`.
- `app.use(csrfProtection);` after `app.use(cookieParser());` (and before route registration).
- Optionally expose a read-only endpoint like `GET /csrf-token` that returns `req.csrfToken()` for the frontend to use, but this adds behavior (a new endpoint) without altering existing ones.

This ensures all subsequent handlers (including those using cookies for auth) are now protected by CSRF checks. Any existing clients must start sending the CSRF token in their state-changing requests; otherwise they will start getting 403 errors, which is expected from a security fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
