### PR TITLE
feat(architect): pass domain-specific RAG contexts for components/ent…

### DIFF
--- a/backend/src/agents/ArchitectAgent.js
+++ b/backend/src/agents/ArchitectAgent.js
@@ -70,14 +70,16 @@ export class ArchitectAgent extends BaseAgent {
     }, version);
     const agentSettings = { ...settings, systemInstruction };
 
-    // 1. System Components
-    const components = await this.analyzeSystemComponents(poOutput, agentSettings);
+      // settings may include a ragContexts object with domain-specific RAG strings
+      // e.g. settings.ragContexts = { components: '...', entities: '...', principles: '...' }
+      // 1. System Components
+      const components = await this.analyzeSystemComponents(poOutput, { ...settings, ragContext: settings.ragContexts?.components || settings.ragContext });
 
     // 2. Logical Data Model
-    const model = await this.modelEntities(poOutput, components, agentSettings);
+      const model = await this.modelEntities(poOutput, components, { ...settings, ragContext: settings.ragContexts?.entities || settings.ragContext });
 
     // 3. Technical Principles
-    const principles = await this.identifyPrinciples(poOutput, components, model, agentSettings);
+      const principles = await this.identifyPrinciples(poOutput, components, model, { ...settings, ragContext: settings.ragContexts?.principles || settings.ragContext });
 
     return {
       ...components,

--- a/backend/src/agents/ArchitectAgent.js
+++ b/backend/src/agents/ArchitectAgent.js
@@ -73,13 +73,13 @@ export class ArchitectAgent extends BaseAgent {
       // settings may include a ragContexts object with domain-specific RAG strings
       // e.g. settings.ragContexts = { components: '...', entities: '...', principles: '...' }
       // 1. System Components
-      const components = await this.analyzeSystemComponents(poOutput, { ...settings, ragContext: settings.ragContexts?.components || settings.ragContext });
+      const components = await this.analyzeSystemComponents(poOutput, { ...agentSettings, ragContext: settings.ragContexts?.components || settings.ragContext });
 
     // 2. Logical Data Model
-      const model = await this.modelEntities(poOutput, components, { ...settings, ragContext: settings.ragContexts?.entities || settings.ragContext });
+      const model = await this.modelEntities(poOutput, components, { ...agentSettings, ragContext: settings.ragContexts?.entities || settings.ragContext });
 
     // 3. Technical Principles
-      const principles = await this.identifyPrinciples(poOutput, components, model, { ...settings, ragContext: settings.ragContexts?.principles || settings.ragContext });
+      const principles = await this.identifyPrinciples(poOutput, components, model, { ...agentSettings, ragContext: settings.ragContexts?.principles || settings.ragContext });
 
     return {
       ...components,

--- a/backend/src/services/analysisService.js
+++ b/backend/src/services/analysisService.js
@@ -84,12 +84,34 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
 
         // 3. Architect: Design System (Logical Sectional Approach)
         logger.info("--> Agent: Architect");
+
+        // Generate focused search queries for components/entities/principles
+        let ragContexts = {};
+        try {
+            const featureListShort = featureList.slice(0, 8);
+            const queries = await archAgent.generateQueries(featureListShort.length ? featureListShort : [{ name: projectName }]);
+            // queries.queries expected as array of 3; fall back to feature names
+            const qArr = (queries && queries.queries) || (featureListShort.map(f => f.name || f).slice(0,3));
+
+            const fetchPromises = qArr.map((q, idx) => retrieveContext(q, projectId, 5));
+            const fetched = await Promise.all(fetchPromises);
+
+            ragContexts = {
+                components: await formatRagContext(fetched[0] || []),
+                entities: await formatRagContext(fetched[1] || []),
+                principles: await formatRagContext(fetched[2] || [])
+            };
+        } catch (e) {
+            logger.warn({ msg: "Failed to generate domain-specific RAG queries, falling back to generic context", error: e.message });
+            ragContexts = { components: ragContext, entities: ragContext, principles: ragContext };
+        }
+
         archOutput = await archAgent.designSystem(poOutput, {
-            projectName,
-            projectId,
-            version: promptVersion,
-            ragContext: ragContext // Inject RAG context into Architect
-        });
+                projectName,
+                projectId,
+                version: promptVersion,
+                ragContexts // Pass domain-specific RAG contexts
+            });
 
         // --- CONTEXT MONITORING ---
         // Safeguard for Free Tier (250k TPM limit)

--- a/backend/src/services/analysisService.js
+++ b/backend/src/services/analysisService.js
@@ -91,9 +91,13 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
             const featureListShort = featureList.slice(0, 8);
             const queries = await archAgent.generateQueries(featureListShort.length ? featureListShort : [{ name: projectName }]);
             // queries.queries expected as array of 3; fall back to feature names
-            const qArr = (queries && queries.queries) || (featureListShort.map(f => f.name || f).slice(0,3));
+            const rawQueries = (queries && queries.queries) || (featureListShort.map(f => f.name || f).slice(0,3));
+            const qArr = rawQueries
+                .map(q => (typeof q === 'string' ? q : (q?.name || JSON.stringify(q))).trim())
+                .filter(q => q.length > 0)
+                .slice(0, 3);
 
-            const fetchPromises = qArr.map((q, idx) => retrieveContext(q, projectId, 5));
+            const fetchPromises = qArr.map((q) => retrieveContext(q, projectId, 5));
             const fetched = await Promise.all(fetchPromises);
 
             ragContexts = {
@@ -102,7 +106,12 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                 principles: await formatRagContext(fetched[2] || [])
             };
         } catch (e) {
-            logger.warn({ msg: "Failed to generate domain-specific RAG queries, falling back to generic context", error: e.message });
+            logger.warn({
+                msg: "Failed to generate domain-specific RAG queries, falling back to generic context",
+                error: e,
+                errorMessage: e instanceof Error ? e.message : String(e),
+                errorStack: e instanceof Error ? e.stack : undefined
+            });
             ragContexts = { components: ragContext, entities: ragContext, principles: ragContext };
         }
 


### PR DESCRIPTION
# feat(architect): pass domain-specific RAG contexts for components/entities/principles

## 📖 Description
Provide domain-specific RAG contexts to the `ArchitectAgent` so each of its sub-calls (components, entities, principles) receives focused retrieval-augmented context instead of the same generic RAG string.

This change:
- Generates focused queries via `ArchitectAgent.generateQueries()` (3 queries targeting components, entities, principles).
- Runs RAG retrieval for each query and compacts results with `formatRagContext()`.
- Passes the three compacted contexts as `settings.ragContexts = { components, entities, principles }` into `ArchitectAgent.designSystem()` so each sub-call receives a domain-specific context.
- Files changed: `backend/src/services/analysisService.js`, `backend/src/agents/ArchitectAgent.js`.

Fixes: (add issue number here if applicable)

---

## 🔄 Type of Change
- [ ] 🐛 Bug Fix
- [x] ✨ New Feature
- [ ] 💥 Breaking Change
- [ ] 📝 Documentation Update
- [ ] 🎨 Style/Refactor
- [ ] 🤖 AI Model/Prompt Update

---

## 🛡️ Governance Checklist
**All checks should be satisfied before merging.**

### Diagram Syntax Authority
- [ ] I have verified that any changes to diagram prompts in `src/utils/prompt_templates/` adhere to strict Mermaid syntax.
- [ ] I have verified the changes using the "View Syntax Explanation" feature in the frontend.
- [x] N/A — this PR does not touch diagram generation logic.

### Architectural Integrity
- [ ] Layer 5 (Document Compiler): PDF/compilation changes are Frontend-Only and contain NO backend dependencies.
- [x] Layer 4 (Refinement): Orchestration/refinement changes are implemented in the backend (`analysisService`) and routed through the service layer.

### Code Quality & Standards
- [x] My code follows the code style of this project (ESLint/Prettier).
- [ ] I have used `shadcn/ui` components where applicable. (N/A — backend change)
- [x] I have removed all `console.log` statements.
- [x] I have performed a self-review of my own code.

---

## 🧪 Verification
How did you verify this change?
- [x] Manual Verification
- [ ] Unit Tests added/updated
- [ ] Snapshot Tests updated (prompt snapshots)

### Verification Steps
1. Pull the branch locally:
   ```bash
   git fetch origin
   git checkout feat/architect-domain-rag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved architecture analysis with domain-specific context grouping for components, entities, and principles.
  * Enhanced context retrieval with targeted query generation and fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aniket-a14/SRA/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->