### PR TITLE
Fix pipeline resilience and auth refresh

### DIFF
--- a/backend/src/agents/BaseAgent.js
+++ b/backend/src/agents/BaseAgent.js
@@ -24,6 +24,26 @@ const MOCK_JSON_RESPONSE = {
         performance: ["Fast"],
         security: ["Secure"]
     },
+    appendices: {
+        analysisModels: {
+            flowchartDiagram: {
+                syntaxExplanation: "Mock workflow",
+                code: "flowchart TD\n  A[Start] --> B[Complete]",
+                caption: "Mock system workflow"
+            },
+            sequenceDiagram: {
+                syntaxExplanation: "Mock interaction",
+                code: "sequenceDiagram\n  User->>System: Request\n  System-->>User: Response",
+                caption: "Mock user interaction"
+            },
+            entityRelationshipDiagram: {
+                syntaxExplanation: "Mock data model",
+                code: "erDiagram\n  USER ||--o{ PROJECT : owns",
+                caption: "Mock data relationships"
+            }
+        },
+        tbdList: []
+    },
     // Reviewer / Critic specific fields
     score: 85,
     status: "APPROVED",
@@ -183,7 +203,11 @@ export class BaseAgent {
                 // A per-day cap reads as a rate limit but never clears inside one run, so
                 // retrying only spends the time budget the pipeline still needs. Fail now
                 // and let the caller surface something the user can act on.
-                if (isRateLimit && isExhaustedQuota(error)) {
+                // Provider SDKs do not agree on the HTTP status for exhausted credits: most
+                // use 429, while some billing/credit responses use 402 or 400. The quota
+                // classifier already distinguishes spent allowances from windowed limits,
+                // so do not require the adapter to label every provider's status as 429.
+                if (isExhaustedQuota(error)) {
                     logger.error({
                         msg: `[${this.name}] Daily quota exhausted — not retrying`,
                         provider: this.provider,

--- a/backend/src/agents/DeveloperAgent.js
+++ b/backend/src/agents/DeveloperAgent.js
@@ -269,6 +269,7 @@ ${rawInput}
     // response constraint. Recover once from an incomplete object instead of silently persisting
     // an appendix section that renders no diagrams.
     logger.warn('[Lead Developer] Appendices response was missing one or more required diagrams; requesting a complete retry.');
+    settings.onStream?.({ type: 'reset' });
     const recovery = await call(`${prompt}
 
 <recovery>

--- a/backend/src/agents/DeveloperAgent.js
+++ b/backend/src/agents/DeveloperAgent.js
@@ -1,4 +1,5 @@
 import { BaseAgent } from './BaseAgent.js';
+import logger from '../config/logger.js';
 import { constructMasterPrompt } from '../utils/prompts.js';
 import { SRSShellSchema, SRSFeaturesSchema, SRSRequirementsSchema, SRSAppendicesSchema } from '../utils/aiSchemas.js';
 import { buildFormatSchema, buildFormatGuidelines } from '../formats/index.js';
@@ -29,6 +30,20 @@ These rules govern ALL Mermaid diagram generation. Violations will produce inval
 10. Limit ERDs to top 10-12 core entities to prevent output truncation.
 </diagram_rules>
 `;
+
+const REQUIRED_APPENDIX_DIAGRAMS = [
+  'flowchartDiagram',
+  'sequenceDiagram',
+  'entityRelationshipDiagram'
+];
+
+export const hasCompleteAppendices = (candidate) => {
+  const models = candidate?.appendices?.analysisModels;
+  return Boolean(
+    models &&
+    REQUIRED_APPENDIX_DIAGRAMS.every((key) => typeof models[key]?.code === 'string' && models[key].code.trim())
+  );
+};
 
 export class DeveloperAgent extends BaseAgent {
   constructor(providerConfig = {}) {
@@ -225,6 +240,7 @@ Each diagram must include "syntaxExplanation", "code", and "caption".
 2. Each diagram must have a concise caption (4-6 words max).
 3. Output RAW Mermaid syntax only (no markdown code blocks).
 4. The TBD list must reference all "TBD" or "To Be Determined" items found in earlier sections.
+5. Return one JSON object in the exact schema above. The outer response is JSON; only each diagram's code field contains raw Mermaid syntax (without markdown fences).
 </constraints>
 
 ${MERMAID_RULES}
@@ -240,11 +256,33 @@ ${rawInput}
 </input>
 `;
 
-    return this.callLLM(prompt, TEMPERATURES.developer, true, SRSAppendicesSchema, 3, 5000, {
+    const call = (instruction) => this.callLLM(instruction, TEMPERATURES.developer, true, SRSAppendicesSchema, 3, 5000, {
       systemInstruction,
       maxOutputTokens: this.tokenLimits.srsAppendices,
       onStream: settings.onStream
     });
+
+    const firstAttempt = await call(prompt);
+    if (hasCompleteAppendices(firstAttempt)) return firstAttempt;
+
+    // Non-Gemini providers receive the schema as prompt guidance rather than a provider-level
+    // response constraint. Recover once from an incomplete object instead of silently persisting
+    // an appendix section that renders no diagrams.
+    logger.warn('[Lead Developer] Appendices response was missing one or more required diagrams; requesting a complete retry.');
+    const recovery = await call(`${prompt}
+
+<recovery>
+The previous response was incomplete. It did not contain non-empty code for all three required
+diagrams. Return a complete JSON object with appendices.analysisModels.flowchartDiagram,
+appendices.analysisModels.sequenceDiagram, and appendices.analysisModels.entityRelationshipDiagram.
+Each must contain non-empty syntaxExplanation, code, and caption fields. Do not omit any required
+field and do not return Mermaid outside the JSON object's code fields.
+</recovery>`);
+
+    if (!hasCompleteAppendices(recovery)) {
+      throw new Error('Appendices generation returned an incomplete required diagram set.');
+    }
+    return recovery;
   }
 
   async generateSRS(requirements, architecture, settings = {}) {

--- a/backend/src/services/analysisService.js
+++ b/backend/src/services/analysisService.js
@@ -458,8 +458,10 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
         // to the next approved BYOK model; do not turn a recoverable quota stop into a
         // COMPLETED/PARTIAL row. The helper is deliberately inside the catch because only
         // this path has the provider error that proves why a switch is needed.
+        let fallbackChainExhausted = false;
         if (analysisId && error?.quotaExhausted && settings?.allowModelFallback === true) {
             let fallbackModel = null;
+            let fallbackSelectionCompleted = false;
             try {
                 fallbackModel = await selectNextFallbackModel(
                     userId,
@@ -472,6 +474,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                         }
                     ]
                 );
+                fallbackSelectionCompleted = true;
             } catch (fallbackLookupError) {
                 logger.warn({
                     msg: '[Pipeline] Could not inspect approved model fallbacks',
@@ -479,6 +482,11 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                     error: fallbackLookupError.message
                 });
             }
+
+            // Only report chain exhaustion when the fallback list was actually inspected.
+            // A lookup failure or a later queue handoff failure is not evidence that the
+            // approved chain has been exhausted.
+            fallbackChainExhausted = fallbackSelectionCompleted && !fallbackModel;
 
             if (fallbackModel) {
                 const fromProvider = providerConfig?.provider || settings.modelProvider || 'unknown';
@@ -503,7 +511,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                 // Persist the new target before publishing. A QStash delivery can start
                 // immediately, so the worker must see the selected fallback in the row and
                 // in its payload even when it races the original invocation's return.
-                analysisMeta = {
+                const fallbackMeta = {
                     ...(analysisMeta || {}),
                     promptSettings: fallbackSettings,
                     fallbackHistory,
@@ -517,7 +525,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                             title: `Switching to ${fallbackModel.modelName}…`,
                             metadata: {
                                 ...persistedMeta,
-                                ...analysisMeta,
+                                ...fallbackMeta,
                                 promptSettings: fallbackSettings,
                                 fallbackHistory,
                                 checkpoint,
@@ -555,6 +563,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                         toProvider: fallbackModel.provider,
                         toModel: fallbackModel.modelName
                     });
+                    analysisMeta = fallbackMeta;
                     return;
                 } catch (handoffError) {
                     // Continue through the normal failure persistence below. The row must
@@ -573,7 +582,6 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
         if (analysisId && srsDraft) {
             const diagramSummary = summarizeGeneratedDiagrams(srsDraft);
             const quotaFailure = error?.quotaExhausted || /quota|429|rate limit/i.test(error.message || '');
-            const fallbackChainExhausted = quotaFailure && settings?.allowModelFallback === true;
             const userFriendlyError = fallbackChainExhausted
                 ? "Analysis finalized early because every approved fallback model was unavailable or out of quota. Add another approved model and resume."
                 : diagramSummary.fixed.length === 3
@@ -586,18 +594,22 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                 diagramSummary
             });
             const { checkpoint: _dropped, ...restMeta } = persistedMeta || {};
+            const resumable = fallbackChainExhausted && Object.keys(checkpoint).length > 0;
             await prisma.analysis.update({
                 where: { id: analysisId },
                 data: {
-                    status: 'COMPLETED', // Mark as completed so user can see the draft
+                    status: fallbackChainExhausted ? 'FAILED' : 'COMPLETED',
                     resultQuality: 'PARTIAL',
                     resultJson: srsDraft,
-                    // A usable draft exists — give the row a real title so it stops reading
-                    // "Analysis in Progress" in the list, and drop the now-moot checkpoint.
-                    title: srsDraft.projectTitle || 'Partial Analysis',
+                    // An exhausted fallback chain remains resumable so the user can add a
+                    // model and continue from the saved draft instead of losing the checkpoint.
+                    title: fallbackChainExhausted
+                        ? 'Analysis paused — model quota'
+                        : srsDraft.projectTitle || 'Partial Analysis',
                     metadata: {
                         ...restMeta,
                         ...(analysisMeta || {}),
+                        ...(resumable ? { checkpoint, resumable: true } : {}),
                         isPartial: true,
                         failureReason: error.message,
                         diagramSummary,
@@ -606,7 +618,18 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                 }
             });
             await invalidateUserAnalysesCache(userId);
-            emitProgress('completed', 'Analysis finalized early (partial result — audit skipped).', { terminal: true, status: 'COMPLETED', resultQuality: 'PARTIAL' });
+            emitProgress(
+                fallbackChainExhausted ? 'failed' : 'completed',
+                fallbackChainExhausted
+                    ? 'Analysis paused after the approved fallback models were exhausted. Add another model and resume.'
+                    : 'Analysis finalized early (partial result — audit skipped).',
+                {
+                    terminal: true,
+                    status: fallbackChainExhausted ? 'FAILED' : 'COMPLETED',
+                    resultQuality: 'PARTIAL',
+                    resumable
+                }
+            );
             return; // Exit early as we've handled the record
         }
 

--- a/backend/src/services/analysisService.js
+++ b/backend/src/services/analysisService.js
@@ -14,6 +14,7 @@ import { DeveloperAgent } from '../agents/DeveloperAgent.js';
 import { ReviewerAgent } from '../agents/ReviewerAgent.js';
 import { CriticAgent } from '../agents/CriticAgent.js';
 import { resolveProviderKey, asAiSettings } from './providers/providerKeyService.js';
+import { selectNextFallbackModel } from './providers/modelFallbackService.js';
 import { publishProgress } from './progressService.js';
 import { STAGE_COST_MS } from './pipelineBudget.js';
 import { triggerReconcileInBackground } from './opportunisticReconcile.js';
@@ -27,6 +28,24 @@ const CACHE_TTL = 3600; // 1 hour in seconds
 // arbitrary padding. See the sectional Developer generation and reflection loop below.
 const AGENT_COOLDOWN_MS = 3000; // between sectional Developer generation calls
 const REFLECTION_LOOP_COOLDOWN_MS = 5000; // before the heavier Reviewer/Critic reflection pass
+
+const summarizeGeneratedDiagrams = (draft) => {
+    const models = draft?.appendices?.analysisModels || {};
+    const fixed = ['flowchartDiagram', 'sequenceDiagram', 'entityRelationshipDiagram'];
+    const fixedPresent = fixed.filter((key) => {
+        const value = models[key];
+        return typeof value === 'string' ? value.trim().length > 0 : Boolean(value?.code?.trim());
+    });
+    const additional = Array.isArray(models.additionalDiagrams)
+        ? models.additionalDiagrams.filter((diagram) => typeof diagram?.code === 'string' && diagram.code.trim()).length
+        : 0;
+
+    return {
+        fixed: fixedPresent,
+        additional,
+        total: fixedPresent.length + additional
+    };
+};
 
 /** Invalidate the cached dashboard list so the UI reflects mutations immediately. */
 const invalidateUserAnalysesCache = async (userId) => {
@@ -434,10 +453,138 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
             ? "AI Rate Limit Exceeded. Please wait a few minutes and try again."
             : `Analysis Error: ${error.message}`;
 
+        // A daily/provider quota failure is recoverable when the user explicitly approved
+        // an ordered fallback chain. Reuse the durable checkpoint and hand the same analysis
+        // to the next approved BYOK model; do not turn a recoverable quota stop into a
+        // COMPLETED/PARTIAL row. The helper is deliberately inside the catch because only
+        // this path has the provider error that proves why a switch is needed.
+        if (analysisId && error?.quotaExhausted && settings?.allowModelFallback === true) {
+            let fallbackModel = null;
+            try {
+                fallbackModel = await selectNextFallbackModel(
+                    userId,
+                    settings,
+                    [
+                        ...(Array.isArray(persistedMeta.fallbackHistory) ? persistedMeta.fallbackHistory : []),
+                        {
+                            provider: providerConfig?.provider || settings.modelProvider,
+                            modelName: providerConfig?.modelName || settings.modelName
+                        }
+                    ]
+                );
+            } catch (fallbackLookupError) {
+                logger.warn({
+                    msg: '[Pipeline] Could not inspect approved model fallbacks',
+                    analysisId,
+                    error: fallbackLookupError.message
+                });
+            }
+
+            if (fallbackModel) {
+                const fromProvider = providerConfig?.provider || settings.modelProvider || 'unknown';
+                const fromModel = providerConfig?.modelName || settings.modelName || 'unknown';
+                const fallbackHistory = [
+                    ...(Array.isArray(persistedMeta.fallbackHistory) ? persistedMeta.fallbackHistory : []),
+                    {
+                        fromProvider,
+                        fromModel,
+                        toProvider: fallbackModel.provider,
+                        toModel: fallbackModel.modelName,
+                        reason: 'quota_exhausted',
+                        switchedAt: new Date().toISOString()
+                    }
+                ];
+                const fallbackSettings = {
+                    ...settings,
+                    modelProvider: fallbackModel.provider,
+                    modelName: fallbackModel.modelName
+                };
+
+                // Persist the new target before publishing. A QStash delivery can start
+                // immediately, so the worker must see the selected fallback in the row and
+                // in its payload even when it races the original invocation's return.
+                analysisMeta = {
+                    ...(analysisMeta || {}),
+                    promptSettings: fallbackSettings,
+                    fallbackHistory,
+                    lastQuotaFallback: fallbackHistory[fallbackHistory.length - 1]
+                };
+                try {
+                    await prisma.analysis.update({
+                        where: { id: analysisId },
+                        data: {
+                            status: 'IN_PROGRESS',
+                            title: `Switching to ${fallbackModel.modelName}…`,
+                            metadata: {
+                                ...persistedMeta,
+                                ...analysisMeta,
+                                promptSettings: fallbackSettings,
+                                fallbackHistory,
+                                checkpoint,
+                                resumable: true,
+                                isPartial: false
+                            }
+                        }
+                    });
+                    await invalidateUserAnalysesCache(userId);
+                    emitProgress(
+                        'model_fallback',
+                        `Quota exhausted for ${fromModel}. Continuing with ${fallbackModel.modelName}…`,
+                        {
+                            status: 'IN_PROGRESS',
+                            modelProvider: fallbackModel.provider,
+                            modelName: fallbackModel.modelName,
+                            fallback: true
+                        }
+                    );
+                    const { enqueueContinuation } = await import('./queueService.js');
+                    await enqueueContinuation({
+                        analysisId,
+                        userId,
+                        text,
+                        projectId,
+                        settings: fallbackSettings,
+                        parentId,
+                        rootId
+                    }, 'quota_fallback');
+                    logger.info({
+                        msg: '[Pipeline] Quota fallback continuation queued',
+                        analysisId,
+                        fromProvider,
+                        fromModel,
+                        toProvider: fallbackModel.provider,
+                        toModel: fallbackModel.modelName
+                    });
+                    return;
+                } catch (handoffError) {
+                    // Continue through the normal failure persistence below. The row must
+                    // not remain IN_PROGRESS when the handoff itself could not be queued.
+                    logger.error({
+                        msg: '[Pipeline] Failed to queue quota fallback continuation',
+                        analysisId,
+                        error: handoffError.message
+                    });
+                }
+            }
+        }
+
         // FAILSAFE: If we have an srsDraft (even if reflection failed),
         // we save it so the user doesn't lose the generation.
         if (analysisId && srsDraft) {
-            logger.info("[Analysis Service] Failsafe: Saving last-known draft despite error.");
+            const diagramSummary = summarizeGeneratedDiagrams(srsDraft);
+            const quotaFailure = error?.quotaExhausted || /quota|429|rate limit/i.test(error.message || '');
+            const fallbackChainExhausted = quotaFailure && settings?.allowModelFallback === true;
+            const userFriendlyError = fallbackChainExhausted
+                ? "Analysis finalized early because every approved fallback model was unavailable or out of quota. Add another approved model and resume."
+                : diagramSummary.fixed.length === 3
+                    ? quotaFailure
+                        ? "Analysis finalized early due to model quota. Diagrams were generated; the global audit was skipped."
+                        : "Analysis finalized early after an AI error. Diagrams were generated; the global audit was skipped."
+                    : "Analysis finalized early before the required diagram set was complete. Resume with a model that has available quota.";
+            logger.info({
+                msg: "[Analysis Service] Failsafe: Saving last-known draft despite error.",
+                diagramSummary
+            });
             const { checkpoint: _dropped, ...restMeta } = persistedMeta || {};
             await prisma.analysis.update({
                 where: { id: analysisId },
@@ -453,7 +600,8 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                         ...(analysisMeta || {}),
                         isPartial: true,
                         failureReason: error.message,
-                        userFriendlyError: "Analysis finalized early due to rate limits. Global audit was skipped."
+                        diagramSummary,
+                        userFriendlyError
                     }
                 }
             });

--- a/backend/src/services/providers/modelFallbackService.js
+++ b/backend/src/services/providers/modelFallbackService.js
@@ -1,6 +1,7 @@
 import { normalizeProvider } from './index.js';
 import { listProviderKeys, resolveProviderKey } from './providerKeyService.js';
 import { isModelExhausted } from './modelQuotaService.js';
+import logger from '../../config/logger.js';
 
 const PROVIDER_VALUES = new Set(['GEMINI', 'OPENAI', 'CLAUDE', 'GROK']);
 
@@ -86,9 +87,16 @@ export const selectNextFallbackModel = async (userId, settings = {}, attempted =
                 inputTokenLimit: resolved.inputTokenLimit,
                 outputTokenLimit: resolved.outputTokenLimit
             };
-        } catch {
+        } catch (error) {
             // The key may have been removed or deactivated while the run was in flight.
             // Continue through the user's ordered list rather than switching implicitly.
+            logger.warn({
+                msg: '[Model fallback] Could not resolve approved provider key',
+                userId,
+                provider: candidate.provider,
+                modelName: candidate.modelName,
+                error: error instanceof Error ? error.message : String(error)
+            });
         }
     }
 

--- a/backend/src/services/providers/modelFallbackService.js
+++ b/backend/src/services/providers/modelFallbackService.js
@@ -1,0 +1,96 @@
+import { normalizeProvider } from './index.js';
+import { listProviderKeys, resolveProviderKey } from './providerKeyService.js';
+import { isModelExhausted } from './modelQuotaService.js';
+
+const PROVIDER_VALUES = new Set(['GEMINI', 'OPENAI', 'CLAUDE', 'GROK']);
+
+const candidateKey = (provider, modelName) => `${provider}:${modelName}`;
+
+/**
+ * Return only well-formed, user-selected fallback candidates.
+ *
+ * The list is intentionally ordered: the order is the user's cost/quality decision and
+ * must be preserved when the pipeline moves from one exhausted model to the next.
+ */
+export const normalizeFallbackCandidates = (fallbackModels) => {
+    if (!Array.isArray(fallbackModels)) return [];
+
+    const seen = new Set();
+    return fallbackModels.reduce((result, candidate) => {
+        const provider = normalizeProvider(candidate?.modelProvider);
+        const modelName = typeof candidate?.modelName === 'string' ? candidate.modelName.trim() : '';
+        if (!PROVIDER_VALUES.has(provider) || !modelName) return result;
+
+        const key = candidateKey(provider, modelName);
+        if (seen.has(key)) return result;
+        seen.add(key);
+        result.push({ provider, modelName });
+        return result;
+    }, []);
+};
+
+/**
+ * Find the next model that the user explicitly approved for this run.
+ *
+ * Availability is checked against the user's stored provider-key discovery result and the
+ * live quota ledger. A missing/stale key, an exhausted model, or a model already attempted
+ * in this fallback chain is skipped. No provider or model is ever invented implicitly.
+ */
+export const selectNextFallbackModel = async (userId, settings = {}, attempted = []) => {
+    if (settings?.allowModelFallback !== true) return null;
+
+    const candidates = normalizeFallbackCandidates(settings.fallbackModels);
+    if (candidates.length === 0) return null;
+
+    const currentProvider = normalizeProvider(settings.modelProvider);
+    const currentModel = typeof settings.modelName === 'string' ? settings.modelName.trim() : '';
+    const attemptedKeys = new Set(
+        (Array.isArray(attempted) ? attempted : [])
+            .flatMap((entry) => [
+                { provider: entry?.provider, modelName: entry?.modelName },
+                { provider: entry?.fromProvider, modelName: entry?.fromModel },
+                { provider: entry?.toProvider, modelName: entry?.toModel }
+            ])
+            .filter((entry) => typeof entry.modelName === 'string' && entry.modelName.trim())
+            .map((entry) => candidateKey(normalizeProvider(entry.provider), entry.modelName.trim()))
+    );
+    if (currentModel) attemptedKeys.add(candidateKey(currentProvider, currentModel));
+
+    const providerKeys = await listProviderKeys(userId);
+
+    for (const candidate of candidates) {
+        const key = candidateKey(candidate.provider, candidate.modelName);
+        if (attemptedKeys.has(key)) continue;
+
+        const providerKey = providerKeys.find((record) => (
+            record.provider === candidate.provider && record.isActive
+        ));
+        if (!providerKey) continue;
+
+        // A discovered list is authoritative for that stored key. Older keys may not have
+        // discovery data, so null/empty discovery remains compatible with the existing BYOK
+        // behavior and is still checked by resolveProviderKey below.
+        const availableModels = providerKey.availableModels;
+        if (Array.isArray(availableModels) && availableModels.length > 0
+            && !availableModels.some((model) => model?.id === candidate.modelName)) {
+            continue;
+        }
+
+        if (await isModelExhausted(userId, candidate.provider, candidate.modelName)) continue;
+
+        try {
+            const resolved = await resolveProviderKey(userId, candidate.provider, candidate.modelName);
+            return {
+                provider: resolved.provider,
+                modelName: resolved.modelName,
+                inputTokenLimit: resolved.inputTokenLimit,
+                outputTokenLimit: resolved.outputTokenLimit
+            };
+        } catch {
+            // The key may have been removed or deactivated while the run was in flight.
+            // Continue through the user's ordered list rather than switching implicitly.
+        }
+    }
+
+    return null;
+};

--- a/backend/src/utils/aiSchemas.js
+++ b/backend/src/utils/aiSchemas.js
@@ -333,7 +333,8 @@ export const SRSAppendicesSchema = {
                                 syntaxExplanation: { type: SchemaType.STRING },
                                 code: { type: SchemaType.STRING },
                                 caption: { type: SchemaType.STRING }
-                            }
+                            },
+                            required: ["syntaxExplanation", "code", "caption"]
                         },
                         sequenceDiagram: {
                             type: SchemaType.OBJECT,
@@ -341,7 +342,8 @@ export const SRSAppendicesSchema = {
                                 syntaxExplanation: { type: SchemaType.STRING },
                                 code: { type: SchemaType.STRING },
                                 caption: { type: SchemaType.STRING }
-                            }
+                            },
+                            required: ["syntaxExplanation", "code", "caption"]
                         },
                         entityRelationshipDiagram: {
                             type: SchemaType.OBJECT,
@@ -349,7 +351,8 @@ export const SRSAppendicesSchema = {
                                 syntaxExplanation: { type: SchemaType.STRING },
                                 code: { type: SchemaType.STRING },
                                 caption: { type: SchemaType.STRING }
-                            }
+                            },
+                            required: ["syntaxExplanation", "code", "caption"]
                         },
                         additionalDiagrams: {
                             type: SchemaType.ARRAY,
@@ -366,10 +369,12 @@ export const SRSAppendicesSchema = {
                                 required: ["type", "title", "code"]
                             }
                         }
-                    }
+                    },
+                    required: ["flowchartDiagram", "sequenceDiagram", "entityRelationshipDiagram"]
                 },
                 tbdList: { type: SchemaType.ARRAY, items: { type: SchemaType.STRING } }
-            }
+            },
+            required: ["analysisModels", "tbdList"]
         }
     },
     required: ["appendices"]

--- a/backend/src/utils/quotaErrors.js
+++ b/backend/src/utils/quotaErrors.js
@@ -20,6 +20,12 @@ const GEMINI_DAILY = /PerDay|per day|GenerateRequestsPerDayPerProject/i;
 // `insufficient_quota` rather than a windowed limit — also not worth retrying.
 const OPENAI_EXHAUSTED = /insufficient_quota|exceeded your current quota/i;
 
+// Anthropic and some OpenAI-compatible gateways use prose rather than a stable error code.
+// Keep this separate from ordinary 429 handling: a provider window such as per-minute or
+// per-second is retryable, while a spent credit/billing/monthly allowance is not.
+const GENERIC_EXHAUSTED = /quota\s+(?:has been\s+)?(?:exceeded|exhausted)|(?:out of|low|insufficient)\s+(?:credits|credit balance)|credit balance\s+(?:is\s+)?(?:too\s+)?(?:low|insufficient)|billing(?:\s+limit)?\s+(?:exceeded|reached)|spend\s+limit\s+(?:exceeded|reached)|payment required/i;
+const WINDOWED_LIMIT = /per[- ]?(?:minute|second|hour)|requests?\s+per\s+(?:minute|second|hour)|tokens?\s+per\s+(?:minute|second|hour)|rate limit/i;
+
 /**
  * @param {Error} error - the provider error, as thrown by an adapter
  * @returns {boolean} true when retrying cannot succeed within this run
@@ -38,7 +44,8 @@ export function isExhaustedQuota(error) {
 
     const haystack = `${structured} ${error.message || ''}`;
 
-    return GEMINI_DAILY.test(haystack) || OPENAI_EXHAUSTED.test(haystack);
+    if (GEMINI_DAILY.test(haystack) || OPENAI_EXHAUSTED.test(haystack)) return true;
+    return GENERIC_EXHAUSTED.test(haystack) && !WINDOWED_LIMIT.test(haystack);
 }
 
 /**

--- a/backend/src/utils/validationSchemas.js
+++ b/backend/src/utils/validationSchemas.js
@@ -23,7 +23,34 @@ export const clientAiSettingsSchema = z.object({
     modelProvider: z.string().optional(),
     modelName: z.string().optional(),
     promptVersion: z.string().max(20).optional(),
-    format: z.enum(['ieee830', 'iso29148', 'volere', 'agile-prd']).optional()
+    format: z.enum(['ieee830', 'iso29148', 'volere', 'agile-prd']).optional(),
+    // Model fallback is opt-in and ordered. The backend only considers these exact
+    // provider/model pairs, so a quota failure never silently changes the user's provider,
+    // billing source, or quality/cost preference.
+    allowModelFallback: z.boolean().optional(),
+    fallbackModels: z.array(z.object({
+        modelProvider: z.enum([
+            'google', 'gemini', 'openai', 'claude', 'anthropic', 'grok', 'xai',
+            'GEMINI', 'OPENAI', 'CLAUDE', 'GROK'
+        ]),
+        modelName: z.string().min(1).max(200)
+    })).max(8).optional()
+}).superRefine((settings, ctx) => {
+    const hasFallbacks = Array.isArray(settings.fallbackModels) && settings.fallbackModels.length > 0;
+    if (hasFallbacks && settings.allowModelFallback !== true) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['allowModelFallback'],
+            message: 'Explicit permission is required before automatic model fallback can be used.'
+        });
+    }
+    if (settings.allowModelFallback === true && !hasFallbacks) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['fallbackModels'],
+            message: 'Choose at least one fallback model before enabling automatic fallback.'
+        });
+    }
 });
 
 export const analyzeSchema = z.object({

--- a/backend/tests/unit/appendices_refinement.test.js
+++ b/backend/tests/unit/appendices_refinement.test.js
@@ -88,6 +88,28 @@ describe('generateAppendices — diagram contract', () => {
         expect(callLLM).toHaveBeenCalledTimes(2);
         expect(hasCompleteAppendices(result)).toBe(true);
     });
+
+    it('resets the active stream before retrying an incomplete appendix', async () => {
+        const agent = new DeveloperAgent();
+        const events = [];
+        const callLLM = jest.spyOn(agent, 'callLLM')
+            .mockImplementationOnce(async (...args) => {
+                args[6]?.onStream?.({ type: 'delta', text: '{"appendices":' });
+                return { appendices: { analysisModels: {}, tbdList: [] } };
+            })
+            .mockImplementationOnce(async (...args) => {
+                args[6]?.onStream?.({ type: 'delta', text: '{"appendices":"complete"}' });
+                return complete();
+            });
+
+        await agent.generateAppendices('input', {}, {}, {}, {
+            appendicesSystemInstruction: 'system',
+            onStream: (event) => events.push(event)
+        });
+
+        expect(callLLM).toHaveBeenCalledTimes(2);
+        expect(events.map((event) => event.type)).toEqual(['delta', 'reset', 'delta']);
+    });
 });
 
 describe('SRSAppendicesSchema — required diagram fields', () => {
@@ -101,9 +123,11 @@ describe('SRSAppendicesSchema — required diagram fields', () => {
             'sequenceDiagram',
             'entityRelationshipDiagram'
         ]));
-        expect(models.properties.flowchartDiagram.required).toEqual(
-            expect.arrayContaining(['syntaxExplanation', 'code', 'caption'])
-        );
+        for (const diagramKey of ['flowchartDiagram', 'sequenceDiagram', 'entityRelationshipDiagram']) {
+            expect(models.properties[diagramKey].required).toEqual(
+                expect.arrayContaining(['syntaxExplanation', 'code', 'caption'])
+            );
+        }
     });
 });
 

--- a/backend/tests/unit/appendices_refinement.test.js
+++ b/backend/tests/unit/appendices_refinement.test.js
@@ -17,7 +17,7 @@ import { jest, describe, it, expect } from '@jest/globals';
 
 const { runReflectionLoop, mergeRefinedAppendices } =
     await import('../../src/services/pipeline/reflectionStage.js');
-const { DeveloperAgent } = await import('../../src/agents/DeveloperAgent.js');
+const { DeveloperAgent, hasCompleteAppendices } = await import('../../src/agents/DeveloperAgent.js');
 const { SRSAppendicesSchema } = await import('../../src/utils/aiSchemas.js');
 
 const diagram = (code) => ({ syntaxExplanation: 'x', code, caption: 'A caption' });
@@ -55,6 +55,55 @@ describe('refineSRS — section schema', () => {
         // Falling back here is what produced a whole document from one section and spread it
         // over the draft. Skipping a quality pass is the cheaper failure.
         await expect(agent.refineSRS('input', {}, {}, {}, 'Glossary', [])).rejects.toThrow(/no schema/i);
+    });
+});
+
+describe('generateAppendices — diagram contract', () => {
+    const complete = () => ({
+        appendices: {
+            analysisModels: {
+                flowchartDiagram: diagram('flowchart TD\n A --> B'),
+                sequenceDiagram: diagram('sequenceDiagram\n A->>B: hi'),
+                entityRelationshipDiagram: diagram('erDiagram\n USER ||--o{ LEAVE : "files"')
+            },
+            tbdList: []
+        }
+    });
+
+    it('recognises only appendices with all required diagram code', () => {
+        expect(hasCompleteAppendices(complete())).toBe(true);
+        expect(hasCompleteAppendices({ appendices: { analysisModels: {} } })).toBe(false);
+    });
+
+    it('recovers once when a provider returns an appendix without diagrams', async () => {
+        const agent = new DeveloperAgent();
+        const callLLM = jest.spyOn(agent, 'callLLM')
+            .mockResolvedValueOnce({ appendices: { analysisModels: {}, tbdList: [] } })
+            .mockResolvedValueOnce(complete());
+
+        const result = await agent.generateAppendices('input', {}, {}, {}, {
+            appendicesSystemInstruction: 'system'
+        });
+
+        expect(callLLM).toHaveBeenCalledTimes(2);
+        expect(hasCompleteAppendices(result)).toBe(true);
+    });
+});
+
+describe('SRSAppendicesSchema — required diagram fields', () => {
+    it('requires the fixed diagram set and its code fields', () => {
+        const appendices = SRSAppendicesSchema.properties.appendices;
+        const models = appendices.properties.analysisModels;
+
+        expect(appendices.required).toEqual(expect.arrayContaining(['analysisModels', 'tbdList']));
+        expect(models.required).toEqual(expect.arrayContaining([
+            'flowchartDiagram',
+            'sequenceDiagram',
+            'entityRelationshipDiagram'
+        ]));
+        expect(models.properties.flowchartDiagram.required).toEqual(
+            expect.arrayContaining(['syntaxExplanation', 'code', 'caption'])
+        );
     });
 });
 

--- a/backend/tests/unit/client_ai_settings.test.js
+++ b/backend/tests/unit/client_ai_settings.test.js
@@ -54,6 +54,16 @@ describe('clientAiSettingsSchema', () => {
         expect(() => parse({ depth: 99 })).toThrow();
         expect(() => parse({ format: 'not-a-format' })).toThrow();
     });
+
+    it('requires explicit permission when fallback models are supplied', () => {
+        const fallbackModels = [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }];
+        expect(() => parse({ fallbackModels })).toThrow(/permission/i);
+        expect(parse({ allowModelFallback: true, fallbackModels })).toEqual({
+            allowModelFallback: true,
+            fallbackModels
+        });
+        expect(() => parse({ allowModelFallback: true })).toThrow(/fallback model/i);
+    });
 });
 
 describe('every route that accepts AI settings strips injection vectors', () => {

--- a/backend/tests/unit/model_fallback.test.js
+++ b/backend/tests/unit/model_fallback.test.js
@@ -89,6 +89,38 @@ describe('selectNextFallbackModel', () => {
         }, [{ provider: 'OPENAI', modelName: 'gpt-backup' }])).resolves.toBeNull();
     });
 
+    it('skips a fallback backed only by an inactive provider key', async () => {
+        mockListProviderKeys.mockResolvedValueOnce([
+            { provider: 'OPENAI', isActive: false, availableModels: [{ id: 'gpt-backup' }] }
+        ]);
+
+        await expect(selectNextFallbackModel('u1', {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }]
+        })).resolves.toBeNull();
+        expect(mockResolveProviderKey).not.toHaveBeenCalled();
+    });
+
+    it('continues to the next approved model when key resolution fails', async () => {
+        mockResolveProviderKey.mockRejectedValueOnce(new Error('key removed'));
+
+        await expect(selectNextFallbackModel('u1', {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [
+                { modelProvider: 'GEMINI', modelName: 'gemini-backup' },
+                { modelProvider: 'OPENAI', modelName: 'gpt-backup' }
+            ]
+        })).resolves.toMatchObject({
+            provider: 'OPENAI',
+            modelName: 'gpt-backup'
+        });
+        expect(mockResolveProviderKey).toHaveBeenCalledTimes(2);
+    });
+
     it('does not revisit a model recorded as a prior fallback destination', async () => {
         await expect(selectNextFallbackModel('u1', {
             modelProvider: 'GEMINI',

--- a/backend/tests/unit/model_fallback.test.js
+++ b/backend/tests/unit/model_fallback.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockListProviderKeys = jest.fn();
+const mockResolveProviderKey = jest.fn();
+const mockIsModelExhausted = jest.fn();
+
+jest.unstable_mockModule('../../src/services/providers/providerKeyService.js', () => ({
+    listProviderKeys: mockListProviderKeys,
+    resolveProviderKey: mockResolveProviderKey
+}));
+jest.unstable_mockModule('../../src/services/providers/modelQuotaService.js', () => ({
+    isModelExhausted: mockIsModelExhausted
+}));
+
+const { normalizeFallbackCandidates, selectNextFallbackModel } =
+    await import('../../src/services/providers/modelFallbackService.js');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockListProviderKeys.mockResolvedValue([
+        {
+            provider: 'GEMINI',
+            isActive: true,
+            availableModels: [{ id: 'gemini-primary' }, { id: 'gemini-backup' }]
+        },
+        {
+            provider: 'OPENAI',
+            isActive: true,
+            availableModels: [{ id: 'gpt-backup' }]
+        }
+    ]);
+    mockIsModelExhausted.mockResolvedValue(false);
+    mockResolveProviderKey.mockImplementation(async (_userId, provider, modelName) => ({
+        provider,
+        modelName,
+        inputTokenLimit: 1000,
+        outputTokenLimit: 500
+    }));
+});
+
+describe('normalizeFallbackCandidates', () => {
+    it('normalizes aliases, preserves order, and removes duplicates', () => {
+        expect(normalizeFallbackCandidates([
+            { modelProvider: 'google', modelName: 'gemini-backup' },
+            { modelProvider: 'OPENAI', modelName: 'gpt-backup' },
+            { modelProvider: 'GEMINI', modelName: 'gemini-backup' },
+            { modelProvider: 'GEMINI', modelName: ' ' }
+        ])).toEqual([
+            { provider: 'GEMINI', modelName: 'gemini-backup' },
+            { provider: 'OPENAI', modelName: 'gpt-backup' }
+        ]);
+    });
+});
+
+describe('selectNextFallbackModel', () => {
+    it('requires explicit permission and chooses the first available approved model', async () => {
+        const settings = {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [
+                { modelProvider: 'GEMINI', modelName: 'gemini-backup' },
+                { modelProvider: 'OPENAI', modelName: 'gpt-backup' }
+            ]
+        };
+
+        await expect(selectNextFallbackModel('u1', settings, [])).resolves.toEqual({
+            provider: 'GEMINI',
+            modelName: 'gemini-backup',
+            inputTokenLimit: 1000,
+            outputTokenLimit: 500
+        });
+    });
+
+    it('skips exhausted, unavailable, and already attempted models', async () => {
+        mockIsModelExhausted.mockImplementation(async (_userId, _provider, modelName) => (
+            modelName === 'gemini-backup'
+        ));
+
+        await expect(selectNextFallbackModel('u1', {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [
+                { modelProvider: 'GEMINI', modelName: 'gemini-backup' },
+                { modelProvider: 'OPENAI', modelName: 'not-discovered' },
+                { modelProvider: 'OPENAI', modelName: 'gpt-backup' }
+            ]
+        }, [{ provider: 'OPENAI', modelName: 'gpt-backup' }])).resolves.toBeNull();
+    });
+
+    it('does not revisit a model recorded as a prior fallback destination', async () => {
+        await expect(selectNextFallbackModel('u1', {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [
+                { modelProvider: 'GEMINI', modelName: 'gemini-backup' },
+                { modelProvider: 'OPENAI', modelName: 'gpt-backup' }
+            ]
+        }, [{
+            fromProvider: 'GEMINI',
+            fromModel: 'gemini-primary',
+            toProvider: 'GEMINI',
+            toModel: 'gemini-backup'
+        }])).resolves.toMatchObject({
+            provider: 'OPENAI',
+            modelName: 'gpt-backup'
+        });
+    });
+
+    it('never selects a model when permission was not granted', async () => {
+        await expect(selectNextFallbackModel('u1', {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            fallbackModels: [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }]
+        })).resolves.toBeNull();
+        expect(mockListProviderKeys).not.toHaveBeenCalled();
+    });
+});

--- a/backend/tests/unit/pipeline_tail_yield.test.js
+++ b/backend/tests/unit/pipeline_tail_yield.test.js
@@ -242,4 +242,47 @@ describe('performAnalysis — yielding in the tail', () => {
         expect(statuses).toContain('IN_PROGRESS');
         expect(statuses).not.toContain('COMPLETED');
     });
+
+    it('does not leave the analysis IN_PROGRESS when the fallback handoff cannot be queued', async () => {
+        mockReflectionLoop.mockRejectedValueOnce(Object.assign(new Error('daily quota exhausted'), {
+            quotaExhausted: true
+        }));
+        mockSelectNextFallbackModel.mockResolvedValueOnce({
+            provider: 'OPENAI',
+            modelName: 'gpt-backup'
+        });
+        mockEnqueueContinuation.mockRejectedValueOnce(new Error('QStash unavailable'));
+
+        await run(createStageBudget(240000), {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }]
+        });
+
+        const lastCall = mockAnalysisUpdate.mock.calls.at(-1)[0];
+        expect(lastCall.data.status).not.toBe('IN_PROGRESS');
+        expect(lastCall.data.metadata.promptSettings?.modelName).not.toBe('gpt-backup');
+    });
+
+    it('keeps an exhausted fallback chain resumable with its checkpoint', async () => {
+        mockReflectionLoop.mockRejectedValueOnce(Object.assign(new Error('daily quota exhausted'), {
+            quotaExhausted: true
+        }));
+        mockSelectNextFallbackModel.mockResolvedValueOnce(null);
+
+        await run(createStageBudget(240000), {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }]
+        });
+
+        const lastCall = mockAnalysisUpdate.mock.calls.at(-1)[0];
+        expect(lastCall.data.status).toBe('FAILED');
+        expect(lastCall.data.resultQuality).toBe('PARTIAL');
+        expect(lastCall.data.metadata.resumable).toBe(true);
+        expect(lastCall.data.metadata.checkpoint.srsDraft).toBeDefined();
+        expect(lastCall.data.metadata.userFriendlyError).toMatch(/add another approved model and resume/i);
+    });
 });

--- a/backend/tests/unit/pipeline_tail_yield.test.js
+++ b/backend/tests/unit/pipeline_tail_yield.test.js
@@ -67,6 +67,21 @@ jest.unstable_mockModule('../../src/services/pipeline/reflectionStage.js', () =>
     isApprovedStatus: () => true
 }));
 
+const mockSelectNextFallbackModel = jest.fn();
+const mockEnqueueContinuation = jest.fn();
+jest.unstable_mockModule('../../src/services/providers/modelFallbackService.js', () => ({
+    selectNextFallbackModel: mockSelectNextFallbackModel
+}));
+jest.unstable_mockModule('../../src/services/queueService.js', () => ({
+    enqueueContinuation: mockEnqueueContinuation
+}));
+jest.unstable_mockModule('../../src/config/redis.js', () => ({
+    getRedisClient: jest.fn(() => null)
+}));
+jest.unstable_mockModule('../../src/services/progressService.js', () => ({
+    publishProgress: jest.fn().mockResolvedValue(undefined)
+}));
+
 jest.unstable_mockModule('../../src/services/knowledge/ragService.js', () => ({
     retrieveContext: jest.fn().mockResolvedValue([]),
     formatRagContext: jest.fn().mockResolvedValue('')
@@ -88,8 +103,8 @@ jest.unstable_mockModule('../../src/services/qualityService.js', () => ({
 const { performAnalysis } = await import('../../src/services/analysisService.js');
 const { createStageBudget, STAGE_COST_MS } = await import('../../src/services/pipelineBudget.js');
 
-const run = (budget) => performAnalysis(
-    'u1', 'build a leave tracker', 'p1', null, 'r1', {}, 'a1', { budget }
+const run = (budget, settings = {}) => performAnalysis(
+    'u1', 'build a leave tracker', 'p1', null, 'r1', settings, 'a1', { budget }
 );
 
 beforeEach(() => {
@@ -98,6 +113,9 @@ beforeEach(() => {
     mockGenerateSrsSections.mockClear();
     mockRepairDiagrams.mockClear();
     mockReflectionLoop.mockClear();
+    mockSelectNextFallbackModel.mockReset();
+    mockEnqueueContinuation.mockReset();
+    mockEnqueueContinuation.mockResolvedValue({ continued: true });
 });
 
 describe('performAnalysis — yielding in the tail', () => {
@@ -184,5 +202,44 @@ describe('performAnalysis — yielding in the tail', () => {
         expect(mockGenerateSrsSections).toHaveBeenCalledTimes(1);
         expect(mockRepairDiagrams).toHaveBeenCalledTimes(1);
         expect(mockReflectionLoop).toHaveBeenCalledTimes(1);
+    });
+
+    it('queues an approved model fallback instead of finalizing a quota failure as partial', async () => {
+        mockReflectionLoop.mockRejectedValueOnce(Object.assign(new Error('daily quota exhausted'), {
+            quotaExhausted: true
+        }));
+        mockSelectNextFallbackModel.mockResolvedValueOnce({
+            provider: 'OPENAI',
+            modelName: 'gpt-backup'
+        });
+
+        await run(createStageBudget(240000), {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }]
+        });
+
+        expect(mockSelectNextFallbackModel).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ allowModelFallback: true }),
+            [{ provider: 'GEMINI', modelName: 'gemini-primary' }]
+        );
+        expect(mockEnqueueContinuation).toHaveBeenCalledWith(
+            expect.objectContaining({
+                analysisId: 'a1',
+                settings: expect.objectContaining({
+                    modelProvider: 'OPENAI',
+                    modelName: 'gpt-backup'
+                })
+            }),
+            'quota_fallback'
+        );
+
+        const statuses = mockAnalysisUpdate.mock.calls
+            .map(([{ data }]) => data.status)
+            .filter(Boolean);
+        expect(statuses).toContain('IN_PROGRESS');
+        expect(statuses).not.toContain('COMPLETED');
     });
 });

--- a/backend/tests/unit/quota_errors.test.js
+++ b/backend/tests/unit/quota_errors.test.js
@@ -37,6 +37,11 @@ describe('quotaErrors', () => {
             expect(isExhaustedQuota(err)).toBe(true);
         });
 
+        it('detects provider billing/credit exhaustion without treating a windowed 429 as daily quota', () => {
+            expect(isExhaustedQuota(new Error('Your credit balance is too low to continue'))).toBe(true);
+            expect(isExhaustedQuota(new Error('Quota exceeded: requests per minute limit reached'))).toBe(false);
+        });
+
         it('ignores unrelated errors and null', () => {
             expect(isExhaustedQuota(new Error('AI Request Timeout'))).toBe(false);
             expect(isExhaustedQuota(new Error('[500] Internal error'))).toBe(false);

--- a/frontend/app/(shell)/analysis/[id]/page.tsx
+++ b/frontend/app/(shell)/analysis/[id]/page.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState, useCallback, useMemo } from "react"
 import { useRouter, useParams } from "next/navigation"
 import { useAuth } from "@/lib/auth-context"
 import useSWR from "swr";
-import { fetcher, swrOptions } from "@/lib/swr-utils";
-import { useAnalysisProgress, useRevalidateOnRestore } from "@/lib/hooks";
+import { createAuthFetcher, swrOptions } from "@/lib/swr-utils";
+import { useAnalysisProgress, useAuthFetch, useRevalidateOnRestore } from "@/lib/hooks";
 
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Sparkles, Save, MessageSquare, FileText } from "lucide-react"
@@ -52,6 +52,8 @@ function AnalysisDetailContent() {
     const id = params?.id as string
     const router = useRouter()
     const { user, token, isLoading: authLoading } = useAuth()
+    const authFetch = useAuthFetch()
+    const swrFetcher = useMemo(() => createAuthFetcher(authFetch), [authFetch])
     const { unlockAndNavigate, unlockLayer, setLayer, setIsFinalized } = useLayer()
 
     const swrKey = useMemo(() => {
@@ -61,7 +63,7 @@ function AnalysisDetailContent() {
 
     const { data: analysis, error: swrError, mutate } = useSWR<Analysis>(
         swrKey,
-        fetcher,
+        swrFetcher,
         {
             ...swrOptions,
             refreshInterval: (latestData) => {

--- a/frontend/app/(shell)/analysis/new/page.tsx
+++ b/frontend/app/(shell)/analysis/new/page.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner"
 import { Folder, Sparkles, SlidersHorizontal, Loader2, ArrowUp, KeyRound } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Slider } from "@/components/ui/slider"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -44,6 +45,14 @@ interface ProviderKeyLite {
     provider: "GEMINI" | "OPENAI" | "CLAUDE" | "GROK"
     isActive: boolean
     availableModels?: { id: string; label: string }[] | null
+}
+
+function canonicalProvider(provider: string | undefined): string {
+    const value = (provider || "").toUpperCase()
+    if (value === "GOOGLE" || value === "GEMINI") return "GEMINI"
+    if (value === "ANTHROPIC") return "CLAUDE"
+    if (value === "XAI") return "GROK"
+    return value
 }
 
 const EXAMPLES = [
@@ -111,6 +120,32 @@ function NewAnalysisContent() {
     // Models the user can actually generate with — driven entirely by their own keys.
     const modelOptions = buildModelOptions(providerKeys)
     const hasNoKeys = keysLoaded && providerKeys.length === 0
+    const fallbackOptions = modelOptions.filter((model) => (
+        !(model.value === settings.modelName
+            && canonicalProvider(model.provider) === canonicalProvider(settings.modelProvider))
+    ))
+    const fallbackModels = settings.fallbackModels || []
+    const isFallbackSelected = (provider: string, modelName: string) => fallbackModels.some((model) => (
+        model.modelName === modelName && canonicalProvider(model.modelProvider) === canonicalProvider(provider)
+    ))
+    const toggleFallbackModel = (provider: string, modelName: string) => {
+        setSettings((prev) => {
+            const current = prev.fallbackModels || []
+            const exists = current.some((model) => (
+                model.modelName === modelName
+                && canonicalProvider(model.modelProvider) === canonicalProvider(provider)
+            ))
+            return {
+                ...prev,
+                fallbackModels: exists
+                    ? current.filter((model) => !(
+                        model.modelName === modelName
+                        && canonicalProvider(model.modelProvider) === canonicalProvider(provider)
+                    ))
+                    : [...current, { modelProvider: provider, modelName }],
+            }
+        })
+    }
 
     // Auto-grow the composer as the description grows, ChatGPT-style.
     useEffect(() => {
@@ -127,6 +162,10 @@ function NewAnalysisContent() {
         }
         if (hasNoKeys) {
             toast.error("Add your own API key in Settings before generating.")
+            return
+        }
+        if (settings.allowModelFallback === true && fallbackModels.length === 0) {
+            toast.error("Choose at least one approved fallback model, or turn automatic fallback off.")
             return
         }
         const desc = description.trim()
@@ -368,6 +407,74 @@ function NewAnalysisContent() {
                                             </p>
                                         </div>
 
+                                        <div className="space-y-2 rounded-lg border border-foreground/10 p-3">
+                                            <div className="flex items-start gap-2">
+                                                <Checkbox
+                                                    id="allow-model-fallback"
+                                                    checked={settings.allowModelFallback === true}
+                                                    disabled={fallbackOptions.length === 0}
+                                                    onCheckedChange={(checked) => setSettings(prev => ({
+                                                        ...prev,
+                                                        allowModelFallback: checked === true,
+                                                        fallbackModels: checked === true ? (prev.fallbackModels || []) : [],
+                                                    }))}
+                                                />
+                                                <div className="space-y-0.5">
+                                                    <Label htmlFor="allow-model-fallback" className="cursor-pointer text-xs">
+                                                        Allow automatic model fallback
+                                                    </Label>
+                                                    <p className="text-[11px] leading-relaxed text-muted-foreground">
+                                                        If this model runs out of quota, continue only with the models you approve below.
+                                                        This may use those stored provider keys and their billing plans.
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            {settings.allowModelFallback === true && fallbackOptions.length > 0 && (
+                                                <div className="space-y-1.5 pl-6">
+                                                    <p className="text-[11px] font-medium text-muted-foreground">Fallback order</p>
+                                                    {fallbackOptions.map((model) => (
+                                                        <label
+                                                            key={`${model.provider}:${model.value}`}
+                                                            className={cn(
+                                                                "flex items-center gap-2 text-xs",
+                                                                quota[quotaKey(model.provider, model.value)]?.isExhausted
+                                                                    ? "cursor-not-allowed text-muted-foreground/50"
+                                                                    : "cursor-pointer"
+                                                            )}
+                                                        >
+                                                            <Checkbox
+                                                                checked={isFallbackSelected(model.provider, model.value)}
+                                                                disabled={quota[quotaKey(model.provider, model.value)]?.isExhausted}
+                                                                onCheckedChange={() => toggleFallbackModel(model.provider, model.value)}
+                                                            />
+                                                            <span>
+                                                                {isFallbackSelected(model.provider, model.value)
+                                                                    ? `${fallbackModels.findIndex((candidate) => (
+                                                                        candidate.modelName === model.value
+                                                                        && canonicalProvider(candidate.modelProvider) === canonicalProvider(model.provider)
+                                                                    )) + 1}. `
+                                                                    : ""}
+                                                                {model.label}{model.hint ? ` · ${model.hint}` : ""}
+                                                                {quota[quotaKey(model.provider, model.value)]?.isExhausted ? " · out of quota" : ""}
+                                                            </span>
+                                                        </label>
+                                                    ))}
+                                                    {fallbackModels.length === 0 && (
+                                                        <p className="text-[11px] text-amber-700">
+                                                            Choose at least one model before starting.
+                                                        </p>
+                                                    )}
+                                                </div>
+                                            )}
+
+                                            {fallbackOptions.length === 0 && (
+                                                <p className="pl-6 text-[11px] text-muted-foreground">
+                                                    Add or verify another provider model in Settings to enable fallback.
+                                                </p>
+                                            )}
+                                        </div>
+
                                         <div className="space-y-1.5">
                                             <Label>Analyst persona</Label>
                                             <div className="grid gap-1">
@@ -429,7 +536,8 @@ function NewAnalysisContent() {
                             size="icon"
                             className="h-8 w-8 rounded-full bg-foreground hover:bg-foreground/90 text-background shrink-0 disabled:opacity-40"
                             onClick={handleAnalyze}
-                            disabled={isAnalyzing || !description.trim() || hasNoKeys}
+                            disabled={isAnalyzing || !description.trim() || hasNoKeys
+                                || (settings.allowModelFallback === true && fallbackModels.length === 0)}
                             aria-label="Start analysis"
                         >
                             {isAnalyzing ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}

--- a/frontend/app/(shell)/analysis/new/page.tsx
+++ b/frontend/app/(shell)/analysis/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Suspense, useEffect, useRef, useState } from "react"
+import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { useAuth } from "@/lib/auth-context"
@@ -118,16 +118,26 @@ function NewAnalysisContent() {
     }, [token])
 
     // Models the user can actually generate with — driven entirely by their own keys.
-    const modelOptions = buildModelOptions(providerKeys)
+    const modelOptions = useMemo(() => buildModelOptions(providerKeys), [providerKeys])
     const hasNoKeys = keysLoaded && providerKeys.length === 0
-    const fallbackOptions = modelOptions.filter((model) => (
+    const fallbackOptions = useMemo(() => modelOptions.filter((model) => (
         !(model.value === settings.modelName
             && canonicalProvider(model.provider) === canonicalProvider(settings.modelProvider))
-    ))
-    const fallbackModels = settings.fallbackModels || []
-    const isFallbackSelected = (provider: string, modelName: string) => fallbackModels.some((model) => (
+    )), [modelOptions, settings.modelName, settings.modelProvider])
+    const availableFallbackOptions = useMemo(() => fallbackOptions.filter((model) => (
+        !quota[quotaKey(model.provider, model.value)]?.isExhausted
+    )), [fallbackOptions, quota])
+    const fallbackModels = useMemo(() => settings.fallbackModels || [], [settings.fallbackModels])
+    const eligibleFallbackModels = useMemo(() => fallbackModels.filter((model) => (
+        availableFallbackOptions.some((option) => (
+            option.value === model.modelName
+            && canonicalProvider(option.provider) === canonicalProvider(model.modelProvider)
+        ))
+    )), [availableFallbackOptions, fallbackModels])
+    const isFallbackSelected = (provider: string, modelName: string) => eligibleFallbackModels.some((model) => (
         model.modelName === modelName && canonicalProvider(model.modelProvider) === canonicalProvider(provider)
     ))
+
     const toggleFallbackModel = (provider: string, modelName: string) => {
         setSettings((prev) => {
             const current = prev.fallbackModels || []
@@ -164,7 +174,7 @@ function NewAnalysisContent() {
             toast.error("Add your own API key in Settings before generating.")
             return
         }
-        if (settings.allowModelFallback === true && fallbackModels.length === 0) {
+        if (settings.allowModelFallback === true && eligibleFallbackModels.length === 0) {
             toast.error("Choose at least one approved fallback model, or turn automatic fallback off.")
             return
         }
@@ -204,7 +214,13 @@ function NewAnalysisContent() {
                         },
                     },
                     projectId: projectId || undefined,
-                    settings,
+                    settings: {
+                        ...settings,
+                        // Project settings can contain a fallback that was later made primary,
+                        // removed from a provider key, or exhausted. Submit only choices that
+                        // are still visible and usable in this run.
+                        fallbackModels: eligibleFallbackModels,
+                    },
                     draft: true,
                 }),
             })
@@ -412,7 +428,7 @@ function NewAnalysisContent() {
                                                 <Checkbox
                                                     id="allow-model-fallback"
                                                     checked={settings.allowModelFallback === true}
-                                                    disabled={fallbackOptions.length === 0}
+                                                    disabled={availableFallbackOptions.length === 0}
                                                     onCheckedChange={(checked) => setSettings(prev => ({
                                                         ...prev,
                                                         allowModelFallback: checked === true,
@@ -436,6 +452,7 @@ function NewAnalysisContent() {
                                                     {fallbackOptions.map((model) => (
                                                         <label
                                                             key={`${model.provider}:${model.value}`}
+                                                            htmlFor={`fallback-${model.provider}-${model.value}`}
                                                             className={cn(
                                                                 "flex items-center gap-2 text-xs",
                                                                 quota[quotaKey(model.provider, model.value)]?.isExhausted
@@ -444,13 +461,14 @@ function NewAnalysisContent() {
                                                             )}
                                                         >
                                                             <Checkbox
+                                                                id={`fallback-${model.provider}-${model.value}`}
                                                                 checked={isFallbackSelected(model.provider, model.value)}
                                                                 disabled={quota[quotaKey(model.provider, model.value)]?.isExhausted}
                                                                 onCheckedChange={() => toggleFallbackModel(model.provider, model.value)}
                                                             />
                                                             <span>
                                                                 {isFallbackSelected(model.provider, model.value)
-                                                                    ? `${fallbackModels.findIndex((candidate) => (
+                                                                    ? `${eligibleFallbackModels.findIndex((candidate) => (
                                                                         candidate.modelName === model.value
                                                                         && canonicalProvider(candidate.modelProvider) === canonicalProvider(model.provider)
                                                                     )) + 1}. `
@@ -460,7 +478,7 @@ function NewAnalysisContent() {
                                                             </span>
                                                         </label>
                                                     ))}
-                                                    {fallbackModels.length === 0 && (
+                                                    {eligibleFallbackModels.length === 0 && (
                                                         <p className="text-[11px] text-amber-700">
                                                             Choose at least one model before starting.
                                                         </p>
@@ -537,7 +555,7 @@ function NewAnalysisContent() {
                             className="h-8 w-8 rounded-full bg-foreground hover:bg-foreground/90 text-background shrink-0 disabled:opacity-40"
                             onClick={handleAnalyze}
                             disabled={isAnalyzing || !description.trim() || hasNoKeys
-                                || (settings.allowModelFallback === true && fallbackModels.length === 0)}
+                                || (settings.allowModelFallback === true && eligibleFallbackModels.length === 0)}
                             aria-label="Start analysis"
                         >
                             {isAnalyzing ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}

--- a/frontend/app/(shell)/analysis/page.tsx
+++ b/frontend/app/(shell)/analysis/page.tsx
@@ -4,8 +4,8 @@ import { useEffect, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/lib/auth-context"
 import useSWR from "swr";
-import { fetcher, swrOptions } from "@/lib/swr-utils";
-import { useRevalidateOnRestore } from "@/lib/hooks";
+import { createAuthFetcher, swrOptions } from "@/lib/swr-utils";
+import { useAuthFetch, useRevalidateOnRestore } from "@/lib/hooks";
 
 import { AnalysisHistory } from "@/components/analysis-history"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -22,6 +22,8 @@ type AnalysisHistoryItem = {
 export default function AnalysisPage() {
     const router = useRouter()
     const { user, token, isLoading: authLoading } = useAuth()
+    const authFetch = useAuthFetch()
+    const swrFetcher = useMemo(() => createAuthFetcher(authFetch), [authFetch])
 
     const swrKey = useMemo(() => {
         if (!token || authLoading) return null;
@@ -30,7 +32,7 @@ export default function AnalysisPage() {
 
     const { data: historyData, error, mutate } = useSWR<AnalysisHistoryItem[]>(
         swrKey,
-        fetcher,
+        swrFetcher,
         swrOptions
     );
 

--- a/frontend/app/(shell)/projects/page.tsx
+++ b/frontend/app/(shell)/projects/page.tsx
@@ -6,7 +6,8 @@ import { useAuth } from "@/lib/auth-context";
 import { fetchProjects, createProject } from "@/lib/projects-api";
 import { Project } from "@/types/project";
 import useSWR from "swr";
-import { fetcher, swrOptions } from "@/lib/swr-utils";
+import { createAuthFetcher, swrOptions } from "@/lib/swr-utils";
+import { useAuthFetch } from "@/lib/hooks";
 
 import Link from "next/link";
 import { toast } from "sonner";
@@ -43,6 +44,8 @@ function initials(name: string) {
 
 export default function ProjectsPage() {
     const { token, isLoading: isAuthLoading } = useAuth();
+    const authFetch = useAuthFetch();
+    const swrFetcher = useMemo(() => createAuthFetcher(authFetch), [authFetch]);
     const router = useRouter();
     const [projects, setProjects] = useState<Project[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -54,7 +57,7 @@ export default function ProjectsPage() {
         if (!token) return null;
         return [`${process.env.NEXT_PUBLIC_BACKEND_URL}/analyze`, token] as const;
     }, [token]);
-    const { data: recentData } = useSWR<AnalysisHistoryItem[]>(recentSwrKey, fetcher, swrOptions);
+    const { data: recentData } = useSWR<AnalysisHistoryItem[]>(recentSwrKey, swrFetcher, swrOptions);
     const recent = (Array.isArray(recentData) ? recentData : []).slice(0, 6);
 
     useEffect(() => {

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -30,7 +30,8 @@ import { useLayer } from "@/lib/layer-context"
 import { useRouter, useParams } from "next/navigation"
 import { useAuth } from "@/lib/auth-context"
 import useSWR from "swr"
-import { fetcher, swrOptions } from "@/lib/swr-utils"
+import { createAuthFetcher, swrOptions } from "@/lib/swr-utils"
+import { useAuthFetch } from "@/lib/hooks"
 import { useCompletionNotifications } from "@/lib/use-completion-notifications"
 import { useMemo } from "react"
 
@@ -77,6 +78,8 @@ export function AppSidebar({ className, inSheet = false }: AppSidebarProps) {
     const router = useRouter()
     const params = useParams()
     const { token, user, logout } = useAuth()
+    const authFetch = useAuthFetch()
+    const swrFetcher = useMemo(() => createAuthFetcher(authFetch), [authFetch])
 
     const analysisId = params?.id as string | undefined
 
@@ -87,7 +90,7 @@ export function AppSidebar({ className, inSheet = false }: AppSidebarProps) {
         return [`${process.env.NEXT_PUBLIC_BACKEND_URL}/analyze`, token] as const
     }, [token])
 
-    const { data: historyData } = useSWR<AnalysisHistoryItem[]>(swrKey, fetcher, {
+    const { data: historyData } = useSWR<AnalysisHistoryItem[]>(swrKey, swrFetcher, {
         ...swrOptions,
         refreshInterval: 30000,
     })
@@ -106,7 +109,7 @@ export function AppSidebar({ className, inSheet = false }: AppSidebarProps) {
         if (!token) return null
         return [`${process.env.NEXT_PUBLIC_BACKEND_URL}/projects`, token] as const
     }, [token])
-    const { data: projectsData } = useSWR<ProjectSummary[]>(projectsSwrKey, fetcher, swrOptions)
+    const { data: projectsData } = useSWR<ProjectSummary[]>(projectsSwrKey, swrFetcher, swrOptions)
     const projects = Array.isArray(projectsData) ? projectsData : []
 
     const handleLogout = () => {

--- a/frontend/lib/swr-utils.test.ts
+++ b/frontend/lib/swr-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest"
+import { createAuthFetcher } from "./swr-utils"
+
+const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    })
+
+describe("createAuthFetcher", () => {
+    it("delegates requests to the shared auth fetch and unwraps API data", async () => {
+        const authFetch = vi.fn().mockResolvedValue(jsonResponse({ data: { id: "a1" } }))
+        const fetcher = createAuthFetcher(authFetch)
+
+        await expect(fetcher(["https://api.example/analyze/a1", "stale-token"])).resolves.toEqual({ id: "a1" })
+        expect(authFetch).toHaveBeenCalledWith("https://api.example/analyze/a1")
+    })
+
+    it("surfaces the replay response when the shared auth fetch cannot recover", async () => {
+        const authFetch = vi.fn().mockResolvedValue(jsonResponse({ message: "Unauthorized" }, 401))
+        const fetcher = createAuthFetcher(authFetch)
+
+        await expect(fetcher(["https://api.example/projects", "stale-token"])).rejects.toMatchObject({
+            message: "Unauthorized",
+            status: 401,
+        })
+    })
+})

--- a/frontend/lib/swr-utils.ts
+++ b/frontend/lib/swr-utils.ts
@@ -1,34 +1,29 @@
 import { toast } from "sonner";
 
-export const fetcher = async ([url, token]: [string, string | null]) => {
-    const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        'Pragma': 'no-cache',
-        'Cache-Control': 'no-cache',
+/**
+ * Build an SWR fetcher from the shared authenticated request function.
+ *
+ * The old SWR fetcher duplicated bearer-header setup with a raw fetch. That meant an SWR
+ * revalidation could see an expired access token, return 401, and stop there even though the
+ * auth context had a valid refresh cookie. `useAuthFetch` owns the refresh/replay contract, so
+ * SWR must use it too.
+ */
+export const createAuthFetcher = (authFetch: (url: string, options?: RequestInit) => Promise<Response>) =>
+    async ([url]: readonly [string, string | null]) => {
+        const res = await authFetch(url);
+        if (!res.ok) {
+            const errorData = await res.json().catch(() => ({}));
+            const error = new Error(errorData.message || 'An error occurred while fetching data.');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (error as any).status = res.status;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (error as any).info = errorData;
+            throw error;
+        }
+
+        const json = await res.json();
+        return json.data || json;
     };
-
-    if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-    }
-
-    const res = await fetch(url, {
-        headers,
-        credentials: 'include'
-    });
-
-    if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        const error = new Error(errorData.message || 'An error occurred while fetching data.');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (error as any).status = res.status;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (error as any).info = errorData;
-        throw error;
-    }
-
-    const json = await res.json();
-    return json.data || json;
-};
 
 export const swrOptions = {
     // Analyses run in the background and change while nobody is looking at them, so a

--- a/frontend/types/analysis.ts
+++ b/frontend/types/analysis.ts
@@ -217,6 +217,11 @@ export interface StartAnalysisInput {
         modelProvider?: string;
         modelName?: string;
         format?: string;
+        allowModelFallback?: boolean;
+        fallbackModels?: Array<{
+            modelProvider: string;
+            modelName: string;
+        }>;
     }
     srsData?: {
         details?: {

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -7,6 +7,11 @@ export interface PromptSettings {
     modelProvider?: 'google' | 'openai' | 'claude' | 'grok';
     modelName?: string;
     format?: string;
+    allowModelFallback?: boolean;
+    fallbackModels?: Array<{
+        modelProvider: string;
+        modelName: string;
+    }>;
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary
- repair sectional diagram generation and appendices refinement
- add consented, ordered model fallback when a provider model is quota-exhausted
- refresh/replay expired access tokens through the existing SWR auth path

## Verification
- Backend: 60 suites, 451 tests, 3 snapshots passed
- Frontend: 8 test files, 87 tests, TypeScript, and ESLint passed
- `git diff --check` passed

## Permission UI
The fallback consent is shown in the new-analysis composer: `/analysis/new` → sliders/settings icon beside the model selector → **Analysis settings** → **Allow automatic model fallback**. Enabling it reveals the ordered fallback model checkboxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional automatic model fallback when an AI provider reaches its quota.
  * Users can select approved backup models and view their availability before starting analysis.
  * Analysis results now provide clearer status messages and diagram summaries when generation is incomplete.

* **Bug Fixes**
  * Improved authenticated data loading across analysis and project pages.
  * Added recovery for incomplete diagram generation, with clearer validation of required diagrams.
  * Improved distinction between temporary rate limits and exhausted quotas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->