### PR TITLE
Issue triage: BYOK localStorage fix, Bruno API collection, Playwright scaffold

### DIFF
--- a/.github/workflows/api-collection.yml
+++ b/.github/workflows/api-collection.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "backend/**"
       - "bruno/**"
+      - ".github/workflows/api-collection.yml"
   pull_request:
     branches: [ "main" ]
     paths:
       - "backend/**"
       - "bruno/**"
+      - ".github/workflows/api-collection.yml"
 
 jobs:
   bruno-run:

--- a/.github/workflows/api-collection.yml
+++ b/.github/workflows/api-collection.yml
@@ -1,0 +1,116 @@
+name: API Collection
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "backend/**"
+      - "bruno/**"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "backend/**"
+      - "bruno/**"
+
+jobs:
+  bruno-run:
+    runs-on: ubuntu-latest
+
+    # pgvector, not plain postgres — schema.prisma's datasource declares the `vector`
+    # extension, and an early migration (20251223111121_add_pgvector) creates it; plain
+    # postgres has no such extension to create, so `prisma migrate deploy` would fail.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sra_bruno_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sra_bruno_ci
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/sra_bruno_ci
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Apply migrations
+      run: pnpm --filter backend exec prisma migrate deploy
+
+    - name: Start backend
+      # MOCK_AI/MOCK_QSTASH mean this run makes no real Gemini call and no real Upstash
+      # publish — GEMINI_API_KEY/QSTASH_TOKEN below only need to satisfy env.js's zod schema,
+      # not authenticate against anything real. REDIS_URL is intentionally unset: the backend
+      # falls back to in-memory rate limiting, so this run never touches a shared Redis.
+      run: nohup node src/server.js > /tmp/backend.log 2>&1 &
+      working-directory: ./backend
+      env:
+        NODE_ENV: development
+        MOCK_AI: 'true'
+        MOCK_QSTASH: 'true'
+        PORT: '3000'
+        JWT_SECRET: ci-bruno-jwt-secret-at-least-32-characters-long
+        COOKIE_SECRET: ci-bruno-cookie-secret
+        ENCRYPTION_KEY: ci-bruno-encryption-key-16char
+        ENCRYPTION_SALT: ci-bruno-encryption-salt
+        BACKUP_ENCRYPTION_SALT: ci-bruno-backup-salt
+        GEMINI_API_KEY: mock-not-used
+        QSTASH_TOKEN: mock-not-used
+        FRONTEND_URL: http://localhost:3001
+        BACKEND_URL: http://localhost:3000
+        ALLOWED_ORIGINS: http://localhost:3001
+
+    - name: Wait for backend to become healthy
+      run: |
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:3000/api/health > /dev/null; then
+            echo "Backend is up"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "Backend did not become healthy in time"
+        cat /tmp/backend.log || true
+        exit 1
+
+    - name: Run Bruno API collection
+      # bru's CLI only runs from inside a collection directory (the one holding bruno.json).
+      run: npx --yes @usebruno/cli run . -r --env dev
+      working-directory: ./bruno
+
+    - name: Show backend log on failure
+      if: failure()
+      run: cat /tmp/backend.log || true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -88,3 +88,57 @@ jobs:
     - name: Run Build
       run: pnpm --filter frontend run build
       working-directory: ./frontend
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Install Playwright's Chromium
+      run: npx playwright install --with-deps chromium
+      working-directory: ./frontend
+
+    - name: Run Playwright E2E suite
+      # playwright.config.ts's webServer starts `npm run dev` itself with
+      # NEXT_PUBLIC_BACKEND_URL pointed at an address nothing listens on — every request the
+      # specs make is mocked at the browser network layer (see tests/e2e/mocks.ts), so this
+      # needs no backend, database, or real provider keys.
+      run: pnpm --filter frontend run test:e2e
+      env:
+        CI: 'true'
+
+    - name: Upload Playwright report
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: frontend/playwright-report
+        retention-days: 14

--- a/Readme.md
+++ b/Readme.md
@@ -185,6 +185,7 @@ SRA leverages professional GitHub Actions for continuous quality assurance and o
 - **Automated Docker Builds**: Multi-stage Docker builds triggered on every push to `main`, publishing optimized images to GHCR.
 - **Bundle Size Monitoring**: Tracks and reports JavaScript bundle size changes for the Next.js frontend, preventing performance regressions.
 - **Linting & Formatting**: Enforces consistent code style and catches potential errors early in the development cycle.
+- **API Contract Testing**: A version-controlled [Bruno](https://www.usebruno.com/) collection (`bruno/`) exercises the auth/project/analysis/settings routes against a real running backend on every PR, catching route-level regressions the Jest suite's mocked tests can't.
 
 ### 🩺 Health & Security Monitoring
 - **Scheduled Health Checks**: Hourly automated uptime verification of the entire SRA pipeline.

--- a/bruno/00-health/01-health-check.bru
+++ b/bruno/00-health/01-health-check.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Health Check
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+tests {
+  test("reports operational status", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data.status).to.equal("UP");
+    expect(res.body.data.services.database).to.equal("UP");
+  });
+}

--- a/bruno/01-auth/01-signup.bru
+++ b/bruno/01-auth/01-signup.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Signup
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/auth/signup
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "email": "{{testEmail}}",
+    "password": "{{testPassword}}",
+    "name": "Bruno CI"
+  }
+}
+
+script:pre-request {
+  // A fresh identity per run so re-running the collection locally never collides with a
+  // previous run's account.
+  const unique = `bruno-ci-${Date.now()}-${Math.floor(Math.random() * 100000)}@example.com`;
+  bru.setVar("testEmail", unique);
+  bru.setVar("testPassword", "Bruno-CI-Pass-1234!");
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("accessToken", res.body.token);
+    bru.setVar("userId", res.body.user.id);
+  }
+}
+
+tests {
+  test("signup succeeds", function () {
+    expect(res.status).to.equal(201);
+    expect(res.body.token).to.be.a("string");
+    expect(res.body.user.email).to.equal(bru.getVar("testEmail"));
+  });
+
+  test("refresh token cookie is set", function () {
+    // The refresh token must never appear in the JSON body — only as an httpOnly cookie.
+    expect(res.body.refreshToken).to.be.undefined;
+  });
+}

--- a/bruno/01-auth/02-login.bru
+++ b/bruno/01-auth/02-login.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Login
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/auth/login
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "email": "{{testEmail}}",
+    "password": "{{testPassword}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200) {
+    bru.setVar("accessToken", res.body.token);
+  }
+}
+
+tests {
+  test("login succeeds with the account just created", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.token).to.be.a("string");
+    expect(res.body.user.email).to.equal(bru.getVar("testEmail"));
+  });
+}

--- a/bruno/01-auth/03-me.bru
+++ b/bruno/01-auth/03-me.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Get Current User
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/auth/me
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("returns the caller's own profile, scoped to their token", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.email).to.equal(bru.getVar("testEmail"));
+  });
+
+  test("never leaks fields outside the toPublicUser whitelist", function () {
+    // Regression guard for tenant-isolation rule: toPublicUser is a whitelist, so nothing
+    // resembling a credential should ever come back on this endpoint.
+    expect(res.body.password).to.be.undefined;
+    expect(res.body.passwordHash).to.be.undefined;
+  });
+}

--- a/bruno/01-auth/04-refresh.bru
+++ b/bruno/01-auth/04-refresh.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Refresh Access Token
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/auth/refresh
+  body: none
+  auth: none
+}
+
+headers {
+  Origin: {{frontendOrigin}}
+}
+
+docs {
+  /auth/refresh is CSRF-guarded (requireTrustedOrigin): it authenticates with the ambient
+  refresh cookie, so it only proceeds past the guard for callers presenting an allowlisted
+  Origin, same as a real browser would.
+}
+
+script:post-response {
+  if (res.status === 200) {
+    bru.setVar("accessToken", res.body.token);
+  }
+}
+
+tests {
+  test("exchanges the httpOnly refresh cookie for a new access token", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.token).to.be.a("string");
+  });
+}

--- a/bruno/02-projects/01-create-project.bru
+++ b/bruno/02-projects/01-create-project.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Create Project
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/projects
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "name": "Bruno CI Project",
+    "description": "Created by the Bruno API collection run"
+  }
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("projectId", res.body.data.id);
+  }
+}
+
+tests {
+  test("creates a project scoped to the caller", function () {
+    expect(res.status).to.equal(201);
+    expect(res.body.data.id).to.be.a("string");
+    expect(res.body.data.name).to.equal("Bruno CI Project");
+  });
+}

--- a/bruno/02-projects/02-list-projects.bru
+++ b/bruno/02-projects/02-list-projects.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List Projects
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/projects
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("lists only the caller's own projects", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data).to.be.an("array");
+    expect(res.body.data.some(p => p.id === bru.getVar("projectId"))).to.equal(true);
+  });
+}

--- a/bruno/02-projects/03-get-project.bru
+++ b/bruno/02-projects/03-get-project.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get Project
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/projects/{{projectId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("returns the project with its recent analyses", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data.id).to.equal(bru.getVar("projectId"));
+    expect(res.body.data.analyses).to.be.an("array");
+  });
+}

--- a/bruno/02-projects/04-update-project.bru
+++ b/bruno/02-projects/04-update-project.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Update Project
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/projects/{{projectId}}
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "description": "Updated by the Bruno API collection run"
+  }
+}
+
+tests {
+  test("merges the update without clobbering the name", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data.name).to.equal("Bruno CI Project");
+    expect(res.body.data.description).to.equal("Updated by the Bruno API collection run");
+  });
+}

--- a/bruno/03-analysis/01-create-analysis.bru
+++ b/bruno/03-analysis/01-create-analysis.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Create Analysis
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/analyze
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "text": "Users need to be able to reset their password by requesting a reset link sent to their registered email address. The link must expire after 30 minutes.",
+    "projectId": "{{projectId}}"
+  }
+}
+
+docs {
+  POST /analyze always enqueues and returns 202 immediately — the actual multi-agent
+  pipeline (ProductOwner → RAG → Architect → Developer → reflection/review) runs
+  asynchronously (in-process here, since the server runs with MOCK_QSTASH=true). This
+  request checks the enqueue contract; 02-get-analysis-job polls the result.
+}
+
+script:post-response {
+  if (res.status === 202) {
+    bru.setVar("analysisJobId", res.body.data.id);
+  }
+}
+
+tests {
+  test("queues the analysis and returns a job id", function () {
+    expect(res.status).to.equal(202);
+    expect(res.body.data.id).to.be.a("string");
+    expect(res.body.data.status).to.equal("queued");
+  });
+}

--- a/bruno/03-analysis/02-get-analysis-job.bru
+++ b/bruno/03-analysis/02-get-analysis-job.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Get Analysis Job Status
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/analyze/job/{{analysisJobId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+docs {
+  With MOCK_QSTASH=true the worker runs in-process, so by the time this request fires the
+  job has almost always already finished — this checks the status contract, not a specific
+  status value, since a slow CI runner could still catch it mid-flight.
+}
+
+tests {
+  test("reports a status scoped to the caller (never 'unknown' for a job they just created)", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data.status).to.not.equal("unknown");
+    expect(["DRAFT", "PENDING", "IN_PROGRESS", "COMPLETED", "FAILED"]).to.include(res.body.data.status);
+  });
+}

--- a/bruno/03-analysis/03-get-history.bru
+++ b/bruno/03-analysis/03-get-history.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get Analysis History
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/analyze
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("lists only the caller's own analyses, including the one just queued", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data).to.be.an("array");
+    expect(res.body.data.some(a => a.id === bru.getVar("analysisJobId"))).to.equal(true);
+  });
+}

--- a/bruno/04-settings/01-list-provider-keys.bru
+++ b/bruno/04-settings/01-list-provider-keys.bru
@@ -1,0 +1,29 @@
+meta {
+  name: List Provider Keys
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/settings/provider-keys
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("lists the caller's own BYOK provider keys, masked", function () {
+    expect(res.status).to.equal(200);
+    expect(res.body.data).to.be.an("array");
+  });
+
+  test("never returns a raw key", function () {
+    for (const key of res.body.data) {
+      expect(key.encryptedKey).to.be.undefined;
+      expect(key.apiKey).to.be.undefined;
+    }
+  });
+}

--- a/bruno/05-cleanup/01-delete-project.bru
+++ b/bruno/05-cleanup/01-delete-project.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Delete Project
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/projects/{{projectId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("removes the project this run created", function () {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/05-cleanup/02-logout.bru
+++ b/bruno/05-cleanup/02-logout.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Logout
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/auth/logout
+  body: none
+  auth: none
+}
+
+headers {
+  Origin: {{frontendOrigin}}
+}
+
+docs {
+  Same CSRF guard as /auth/refresh — see that request's docs.
+}
+
+tests {
+  test("revokes the session", function () {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/05-cleanup/03-verify-logged-out.bru
+++ b/bruno/05-cleanup/03-verify-logged-out.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Verify Logged Out
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/auth/refresh
+  body: none
+  auth: none
+}
+
+headers {
+  Origin: {{frontendOrigin}}
+}
+
+docs {
+  Logout returning 200 only proves the endpoint ran, not that the session is actually gone —
+  a handler that no-ops when there's no session to revoke would pass that check too. This
+  replays the same refresh cookie against /auth/refresh right after logout and expects it to
+  be rejected, which is the only thing that actually proves the session was invalidated.
+}
+
+tests {
+  test("the refresh cookie no longer works after logout", function () {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -1,0 +1,39 @@
+# SRA API collection (Bruno)
+
+Covers the auth session lifecycle, project CRUD, the analysis enqueue/status/history
+contract, and provider-key listing — end to end, against a real running backend and
+database (no network mocking; this is not a substitute for the Jest suite, which covers
+business logic in isolation).
+
+## Running locally
+
+1. Start the backend with `MOCK_AI=true` and `MOCK_QSTASH=true` so the run needs no real
+   Gemini key or Upstash queue:
+
+   ```bash
+   cd backend
+   MOCK_AI=true MOCK_QSTASH=true pnpm dev
+   ```
+
+2. From the repo root:
+
+   ```bash
+   npx @usebruno/cli run bruno -r --env local
+   ```
+
+## Folder order
+
+Numbered so a full `-r` run works end to end: `00-health` needs no auth; `01-auth` creates
+a fresh account (a new email per run, so re-running never collides) and leaves an access
+token and refresh cookie behind for every folder after it; `02-projects` and `03-analysis`
+depend on that token; `05-cleanup` deletes the project the run created and logs out last —
+logging out revokes the session, so nothing after it in the run can use the token again.
+
+`/auth/refresh` and `/auth/logout` are CSRF-guarded (`requireTrustedOrigin`): they
+authenticate with the ambient refresh cookie, so both requests send an `Origin` header
+matching `frontendOrigin`, the same way a real browser would.
+
+## Environments
+
+- `local` — a developer's own `pnpm dev` instance on port 3000.
+- `dev` — used by CI (`bru run bruno -r --env dev`), same port, ephemeral database.

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "SRA API",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/bruno/environments/dev.bru
+++ b/bruno/environments/dev.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:3000/api
+  frontendOrigin: http://localhost:3001
+}

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:3000/api
+  frontendOrigin: http://localhost:3001
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/

--- a/frontend/lib/auth-context.test.tsx
+++ b/frontend/lib/auth-context.test.tsx
@@ -35,7 +35,8 @@ const renderAuth = () => render(<AuthProvider><Consumer /></AuthProvider>)
 describe("AuthProvider session survival", () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        localStorage.setItem("token", "stored-access-token")
+        // The access token is never persisted; only the (non-sensitive) cached profile is.
+        // Session restore on mount goes through /auth/refresh exchanging the httpOnly cookie.
         localStorage.setItem("user", JSON.stringify(CACHED_USER))
         // jsdom starts at "/", which the provider treats as a public route and so does not
         // redirect away from. These tests are about signed-in pages.
@@ -51,7 +52,10 @@ describe("AuthProvider session survival", () => {
         // The reported bug: reopening the site hits a cold function, /auth/me 502s, and the
         // app used to call logout() — which revokes the refresh token server-side. A session
         // with days left was destroyed by one slow start.
-        const fetchMock = stubFetch({ "/auth/me": () => json({ message: "Bad Gateway" }, 502) })
+        const fetchMock = stubFetch({
+            "/auth/refresh": () => json({ token: "fresh-access-token" }),
+            "/auth/me": () => json({ message: "Bad Gateway" }, 502)
+        })
         vi.stubGlobal("fetch", fetchMock)
 
         renderAuth()
@@ -59,7 +63,7 @@ describe("AuthProvider session survival", () => {
         await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("false"))
         expect(fetchMock.mock.calls.some(c => String(c[0]).includes("/auth/logout"))).toBe(false)
         expect(screen.getByTestId("user").textContent).toBe(CACHED_USER.email)
-        expect(localStorage.getItem("token")).toBe("stored-access-token")
+        expect(screen.getByTestId("token").textContent).toBe("fresh-access-token")
     })
 
     it("keeps the session when the network is down entirely", async () => {
@@ -70,13 +74,14 @@ describe("AuthProvider session survival", () => {
 
         await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("false"))
         expect(fetchMock.mock.calls.some(c => String(c[0]).includes("/auth/logout"))).toBe(false)
-        expect(localStorage.getItem("token")).toBe("stored-access-token")
+        // Nothing proved the session invalid — the cached profile stays, even with no fresh token yet.
+        expect(screen.getByTestId("user").textContent).toBe(CACHED_USER.email)
+        expect(push).not.toHaveBeenCalledWith("/auth/login")
     })
 
-    it("keeps the session when the token expired but refresh could not be reached", async () => {
-        // 401 then an unreachable refresh proves nothing about the refresh token's validity.
+    it("keeps the session when the refresh endpoint could not be reached", async () => {
+        // An unreachable refresh proves nothing about the refresh token's validity.
         const fetchMock = stubFetch({
-            "/auth/me": () => json({ message: "Unauthorized" }, 401),
             "/auth/refresh": () => json({ message: "Service Unavailable" }, 503)
         })
         vi.stubGlobal("fetch", fetchMock)
@@ -85,35 +90,68 @@ describe("AuthProvider session survival", () => {
 
         await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("false"))
         expect(fetchMock.mock.calls.some(c => String(c[0]).includes("/auth/logout"))).toBe(false)
-        expect(localStorage.getItem("token")).toBe("stored-access-token")
+        expect(screen.getByTestId("user").textContent).toBe(CACHED_USER.email)
+        expect(push).not.toHaveBeenCalledWith("/auth/login")
     })
 
-    it("recovers silently when refresh succeeds", async () => {
-        let meCalls = 0
+    it("recovers silently on mount by exchanging the refresh cookie", async () => {
         const fetchMock = stubFetch({
-            "/auth/me": () => (++meCalls === 1 ? json({}, 401) : json(CACHED_USER)),
-            "/auth/refresh": () => json({ token: "fresh-access-token" })
+            "/auth/refresh": () => json({ token: "fresh-access-token" }),
+            "/auth/me": () => json(CACHED_USER)
         })
         vi.stubGlobal("fetch", fetchMock)
 
         renderAuth()
 
-        await waitFor(() => expect(localStorage.getItem("token")).toBe("fresh-access-token"))
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("fresh-access-token"))
         expect(screen.getByTestId("user").textContent).toBe(CACHED_USER.email)
         expect(fetchMock.mock.calls.some(c => String(c[0]).includes("/auth/logout"))).toBe(false)
+        // No toast/redirect for a legitimate silent recovery.
+        expect(push).not.toHaveBeenCalledWith("/auth/login")
     })
 
-    it("does sign out when the server says the refresh token itself is rejected", async () => {
-        // The one case that is genuine proof the session is over.
+    it("clears the session silently when the mount-time refresh is rejected (no toast, no redirect)", async () => {
+        // A first-time or already-logged-out visitor has no valid refresh cookie either, and
+        // gets the same verdict — neither should see a "session expired" toast.
         const fetchMock = stubFetch({
-            "/auth/me": () => json({}, 401),
-            "/auth/refresh": () => json({ message: "Invalid or Expired Refresh Token" }, 401)
+            "/auth/refresh": () => json({ message: "No refresh token" }, 401)
         })
         vi.stubGlobal("fetch", fetchMock)
 
         renderAuth()
 
-        await waitFor(() => expect(localStorage.getItem("token")).toBeNull())
+        await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("false"))
+        expect(screen.getByTestId("token").textContent).toBe("none")
+        expect(localStorage.getItem("user")).toBeNull()
+        // Silent: no redirect, no toast-triggering round trip beyond the refresh attempt itself.
+        expect(push).not.toHaveBeenCalledWith("/auth/login")
+    })
+
+    it("signs out when the server says the refresh token itself is rejected mid-session", async () => {
+        // The one case that is genuine proof the session is over.
+        const fetchMock = stubFetch({
+            "/auth/refresh": () => json({ token: "fresh-access-token" }),
+            "/auth/me": () => json(CACHED_USER)
+        })
+        vi.stubGlobal("fetch", fetchMock)
+
+        const held: { refresh: () => Promise<unknown> } = { refresh: async () => undefined }
+        function Grabber() {
+            const { refreshAccessToken } = useAuth()
+            useEffect(() => { held.refresh = refreshAccessToken }, [refreshAccessToken])
+            return null
+        }
+        render(<AuthProvider><Consumer /><Grabber /></AuthProvider>)
+
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("fresh-access-token"))
+
+        fetchMock.mockImplementation((url: string) => {
+            if (String(url).includes("/auth/refresh")) return Promise.resolve(json({ message: "Invalid or Expired Refresh Token" }, 401))
+            throw new Error(`unstubbed fetch: ${url}`)
+        })
+        await held.refresh()
+
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("none"))
         expect(localStorage.getItem("user")).toBeNull()
         // Somewhere the user can act. Leaving them in place is what produced a signed-in shell
         // that could navigate but could not load anything behind it.
@@ -128,25 +166,28 @@ describe("AuthProvider session survival", () => {
         // the sign-out lived only in the /auth/me path — which does not run again. The user
         // could keep navigating a shell that could no longer open anything.
         const fetchMock = stubFetch({
-            "/auth/me": () => json(CACHED_USER),
-            "/auth/refresh": () => json({ message: "Invalid or Expired Refresh Token" }, 401)
+            "/auth/refresh": () => json({ token: "fresh-access-token" }),
+            "/auth/me": () => json(CACHED_USER)
         })
         vi.stubGlobal("fetch", fetchMock)
 
         const held: { refresh: () => Promise<unknown> } = { refresh: async () => undefined }
         function Grabber() {
             const { refreshAccessToken } = useAuth()
-            // In an effect, not during render — reassigning outer state while rendering is a
-            // side effect React is free to run more than once.
             useEffect(() => { held.refresh = refreshAccessToken }, [refreshAccessToken])
             return null
         }
-        render(<AuthProvider><Grabber /></AuthProvider>)
+        render(<AuthProvider><Consumer /><Grabber /></AuthProvider>)
 
-        await waitFor(() => expect(localStorage.getItem("token")).toBe("stored-access-token"))
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("fresh-access-token"))
+
+        fetchMock.mockImplementation((url: string) => {
+            if (String(url).includes("/auth/refresh")) return Promise.resolve(json({ message: "Invalid or Expired Refresh Token" }, 401))
+            throw new Error(`unstubbed fetch: ${url}`)
+        })
         await held.refresh()
 
-        await waitFor(() => expect(localStorage.getItem("token")).toBeNull())
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("none"))
         expect(push).toHaveBeenCalledWith("/auth/login")
     })
 
@@ -155,15 +196,9 @@ describe("AuthProvider session survival", () => {
         // deduplicated. The joiner used to be handed the shared promise and returned straight
         // away, skipping the sign-out entirely — so whether the app noticed its session had
         // ended came down to which request happened to lose the race.
-        let releaseRefresh: (() => void) | undefined
-        const gate = new Promise<void>(resolve => { releaseRefresh = resolve })
-
         const fetchMock = stubFetch({
-            "/auth/me": () => json(CACHED_USER),
-            "/auth/refresh": async () => {
-                await gate
-                return json({ message: "Invalid or Expired Refresh Token" }, 401)
-            }
+            "/auth/refresh": () => json({ token: "fresh-access-token" }),
+            "/auth/me": () => json(CACHED_USER)
         })
         vi.stubGlobal("fetch", fetchMock)
 
@@ -173,9 +208,22 @@ describe("AuthProvider session survival", () => {
             useEffect(() => { held.refresh = refreshAccessToken }, [refreshAccessToken])
             return null
         }
-        render(<AuthProvider><Grabber /></AuthProvider>)
+        render(<AuthProvider><Consumer /><Grabber /></AuthProvider>)
 
-        await waitFor(() => expect(localStorage.getItem("token")).toBe("stored-access-token"))
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("fresh-access-token"))
+        // Mount already made its own (successful) refresh call — count only what the
+        // concurrent pair below triggers.
+        const refreshCallsBeforePair = fetchMock.mock.calls.filter(c => String(c[0]).includes("/auth/refresh")).length
+
+        let releaseRefresh: (() => void) | undefined
+        const gate = new Promise<void>(resolve => { releaseRefresh = resolve })
+        fetchMock.mockImplementation(async (url: string) => {
+            if (String(url).includes("/auth/refresh")) {
+                await gate
+                return json({ message: "Invalid or Expired Refresh Token" }, 401)
+            }
+            throw new Error(`unstubbed fetch: ${url}`)
+        })
 
         const first = held.refresh()
         const joiner = held.refresh()
@@ -185,8 +233,9 @@ describe("AuthProvider session survival", () => {
         // The joiner sees the same verdict as the caller that started the request...
         expect(joined).toMatchObject({ token: null, reason: "expired" })
         // ...and one refresh was made, not two — a second would present a rotated-away cookie.
-        expect(fetchMock.mock.calls.filter(c => String(c[0]).includes("/auth/refresh"))).toHaveLength(1)
-        await waitFor(() => expect(localStorage.getItem("token")).toBeNull())
+        const refreshCallsAfterPair = fetchMock.mock.calls.filter(c => String(c[0]).includes("/auth/refresh")).length
+        expect(refreshCallsAfterPair - refreshCallsBeforePair).toBe(1)
+        await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("none"))
         expect(push).toHaveBeenCalledWith("/auth/login")
     })
 })

--- a/frontend/lib/auth-context.test.tsx
+++ b/frontend/lib/auth-context.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { useEffect } from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, act } from "@testing-library/react"
 import { AuthProvider, useAuth } from "./auth-context"
 
 const push = vi.fn()
@@ -237,5 +237,47 @@ describe("AuthProvider session survival", () => {
         expect(refreshCallsAfterPair - refreshCallsBeforePair).toBe(1)
         await waitFor(() => expect(screen.getByTestId("token").textContent).toBe("none"))
         expect(push).toHaveBeenCalledWith("/auth/login")
+    })
+
+    it("does not let a delayed mount-time refresh rejection clear a session established by a later login", async () => {
+        // The race this guards: bootstrapSession's silent refresh is still in flight (e.g. a
+        // slow cold start) when the user submits login on /auth/login before it resolves. A
+        // stale "expired" verdict landing after login must not clear a session it started
+        // before and knows nothing about.
+        window.history.pushState({}, "", "/auth/login")
+        localStorage.clear()
+
+        let releaseRefresh: (() => void) | undefined
+        const gate = new Promise<void>(resolve => { releaseRefresh = resolve })
+        const fetchMock = vi.fn((url: string) => {
+            if (String(url).includes("/auth/refresh")) return gate.then(() => json({ message: "No refresh token" }, 401))
+            if (String(url).includes("/auth/me")) return Promise.resolve(json(CACHED_USER))
+            throw new Error(`unstubbed fetch: ${url}`)
+        })
+        vi.stubGlobal("fetch", fetchMock)
+
+        const held: { login: (token: string, user: typeof CACHED_USER) => void } = { login: () => undefined }
+        function Grabber() {
+            const { login } = useAuth()
+            useEffect(() => { held.login = login }, [login])
+            return null
+        }
+        render(<AuthProvider><Consumer /><Grabber /></AuthProvider>)
+
+        // Wait for the mount-time refresh to actually be in flight before logging in.
+        await waitFor(() => expect(fetchMock.mock.calls.some(c => String(c[0]).includes("/auth/refresh"))).toBe(true))
+
+        act(() => { held.login("logged-in-token", CACHED_USER) })
+        expect(screen.getByTestId("token").textContent).toBe("logged-in-token")
+
+        // Now let the stale, gated refresh resolve its rejection and try to act on it.
+        releaseRefresh?.()
+        await waitFor(() => expect(fetchMock.mock.calls.some(c => String(c[0]).includes("/auth/me"))).toBe(true))
+        // Give the settled refresh's own handling a turn to run, if it were going to.
+        await new Promise(resolve => setTimeout(resolve, 10))
+
+        expect(screen.getByTestId("token").textContent).toBe("logged-in-token")
+        expect(screen.getByTestId("user").textContent).toBe(CACHED_USER.email)
+        expect(push).not.toHaveBeenCalledWith("/auth/login")
     })
 })

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -61,11 +61,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const router = useRouter()
 
     /**
+     * Bumped on every login/authenticateWithToken/clearSession, so the mount-time silent
+     * refresh can tell whether it's still resolving for the session it started for. Without
+     * this, a slow /auth/refresh that started before login can resolve "expired" after login
+     * succeeds and wipe the fresh session it knows nothing about.
+     */
+    const sessionGenRef = React.useRef(0)
+
+    /**
      * Drop every trace of the session on this device and send the user somewhere they can
      * actually act. Separate from logout() because an *expired* session needs no round-trip:
      * the server has already said the refresh token is dead and cleared the cookie itself.
      */
     const clearSession = React.useCallback((destination?: string) => {
+        sessionGenRef.current += 1
         localStorage.removeItem("user")
         setToken(null)
         setUser(null)
@@ -87,7 +96,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         clearSession("/")
     }, [clearSession])
 
-    const refreshAccessToken = React.useCallback(async (opts?: { silent?: boolean }): Promise<RefreshResult> => {
+    const refreshAccessToken = React.useCallback(async (opts?: { silent?: boolean; startGen?: number }): Promise<RefreshResult> => {
         // Join the refresh already running rather than starting a competing one. The joiner
         // falls through to the same handling below, so whichever caller happens to arrive
         // second still sees the expiry — returning the bare promise here meant a page whose
@@ -127,7 +136,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             // visitor who was never signed in has no cookie either, and gets the same "expired"
             // verdict as someone whose session just ended — they must not see a sign-in toast
             // for a session they never had. Same for anywhere already public.
-            if (opts?.silent || onAuthRoute()) {
+            if (opts?.silent) {
+                // A login (or another clearSession) that happened after this refresh started
+                // owns the session now — this "expired" verdict is stale and about a session
+                // that's already gone, not the one currently signed in. Clearing here would
+                // sign out someone who logged in while the mount-time refresh was still
+                // in flight.
+                if (opts.startGen === sessionGenRef.current) {
+                    clearSession()
+                }
+            } else if (onAuthRoute()) {
                 clearSession()
             } else {
                 // Fixed id: several callers can await the same expiry, and the user should be
@@ -206,6 +224,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, [fetchUser, token])
 
     const restoreCachedUser = React.useCallback(() => {
+        // Pre-refresh-cookie builds kept the access token in localStorage too. Purge any
+        // leftover from before this device upgraded — otherwise it sits there, readable by
+        // any injected script, for the rest of its JWT lifetime even though nothing writes
+        // to this key anymore.
+        localStorage.removeItem("token")
         const storedUser = localStorage.getItem("user")
         if (storedUser) {
             try {
@@ -218,8 +241,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const bootstrapSession = React.useCallback(async () => {
         // Regain the session by exchanging the httpOnly refresh cookie for a fresh access
-        // token, same mechanism as a mid-session refresh but silent.
-        const result = await refreshAccessToken({ silent: true })
+        // token, same mechanism as a mid-session refresh but silent. Captures the generation
+        // before the request goes out so a login that lands before this resolves isn't
+        // clobbered by a stale "expired" verdict — see the startGen check in refreshAccessToken.
+        const startGen = sessionGenRef.current
+        const result = await refreshAccessToken({ silent: true, startGen })
         if (!result.token) setIsLoading(false)
     }, [refreshAccessToken])
 
@@ -237,6 +263,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, [])
 
     const login = React.useCallback((newToken: string, newUser: User) => {
+        sessionGenRef.current += 1
         localStorage.setItem("user", JSON.stringify(newUser))
         setToken(newToken)
         setUser(newUser)
@@ -244,6 +271,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, [router])
 
     const authenticateWithToken = React.useCallback(async (newToken: string) => {
+        sessionGenRef.current += 1
         setToken(newToken)
         await fetchUser(newToken)
         router.push("/projects")

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -66,7 +66,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
      * the server has already said the refresh token is dead and cleared the cookie itself.
      */
     const clearSession = React.useCallback((destination?: string) => {
-        localStorage.removeItem("token")
         localStorage.removeItem("user")
         setToken(null)
         setUser(null)
@@ -88,7 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         clearSession("/")
     }, [clearSession])
 
-    const refreshAccessToken = React.useCallback(async (): Promise<RefreshResult> => {
+    const refreshAccessToken = React.useCallback(async (opts?: { silent?: boolean }): Promise<RefreshResult> => {
         // Join the refresh already running rather than starting a competing one. The joiner
         // falls through to the same handling below, so whichever caller happens to arrive
         // second still sees the expiry — returning the bare promise here meant a page whose
@@ -109,7 +108,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 const data = await res.json()
                 if (!data?.token) return { token: null, reason: "expired" }
 
-                localStorage.setItem("token", data.token)
                 setToken(data.token)
                 return { token: data.token as string }
             } catch {
@@ -125,10 +123,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // sign-out at all: navigable, but unable to open anything.
         const result = await shared
         if (result.reason === "expired") {
-            // The stale credentials go either way — leaving them is what made the landing page
-            // keep offering "Dashboard" for a session that no longer existed. Only the
-            // interruption is conditional: somewhere already public needs no announcement.
-            if (onAuthRoute()) {
+            // `silent` is the mount-time exchange of the refresh cookie for an access token: a
+            // visitor who was never signed in has no cookie either, and gets the same "expired"
+            // verdict as someone whose session just ended — they must not see a sign-in toast
+            // for a session they never had. Same for anywhere already public.
+            if (opts?.silent || onAuthRoute()) {
                 clearSession()
             } else {
                 // Fixed id: several callers can await the same expiry, and the user should be
@@ -206,29 +205,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
     }, [fetchUser, token])
 
+    const restoreCachedUser = React.useCallback(() => {
+        const storedUser = localStorage.getItem("user")
+        if (storedUser) {
+            try {
+                setUser(JSON.parse(storedUser))
+            } catch (e) {
+                console.error("Failed to parse cached user", e)
+            }
+        }
+    }, [])
+
+    const bootstrapSession = React.useCallback(async () => {
+        // Regain the session by exchanging the httpOnly refresh cookie for a fresh access
+        // token, same mechanism as a mid-session refresh but silent.
+        const result = await refreshAccessToken({ silent: true })
+        if (!result.token) setIsLoading(false)
+    }, [refreshAccessToken])
+
     useEffect(() => {
-        Promise.resolve().then(() => {
-            const storedToken = localStorage.getItem("token")
-            const storedUser = localStorage.getItem("user")
-
-            if (storedUser) {
-                try {
-                    setUser(JSON.parse(storedUser))
-                } catch (e) {
-                    console.error("Failed to parse cached user", e)
-                }
-            }
-
-            if (storedToken) {
-                setToken(storedToken)
-            } else {
-                setIsLoading(false)
-            }
-        })
+        // The access token is never persisted — only the (non-sensitive) profile is, so a
+        // returning visitor sees their name immediately instead of a loading flash.
+        // Both calls are named functions, not inline setState, and deferred to the next tick
+        // to avoid "setState synchronously in effect" — same pattern as the effect above.
+        Promise.resolve().then(restoreCachedUser)
+        Promise.resolve().then(bootstrapSession)
+        // Mount-only by design: bootstrapSession is not a stable reference (it closes over
+        // the router transitively), and re-running this on every render would re-issue the
+        // refresh-cookie exchange each time.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const login = React.useCallback((newToken: string, newUser: User) => {
-        localStorage.setItem("token", newToken)
         localStorage.setItem("user", JSON.stringify(newUser))
         setToken(newToken)
         setUser(newUser)
@@ -236,7 +244,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, [router])
 
     const authenticateWithToken = React.useCallback(async (newToken: string) => {
-        localStorage.setItem("token", newToken)
         setToken(newToken)
         await fetchUser(newToken)
         router.push("/projects")

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -6,8 +6,9 @@ import { NextRequest, NextResponse } from "next/server";
  * The policy previously carried `script-src 'unsafe-inline'`, which is the one directive
  * that makes the rest of a CSP largely decorative: with it, an injected `<script>` executes
  * like any other, so the policy stops being a defence against XSS and becomes a list of
- * hosts. That mattered here more than usual, because the access token lives in localStorage
- * and is readable by any script that runs.
+ * hosts. That mattered here more than usual, because the access token lives in page memory
+ * and is readable by any script that runs — an injected script doesn't need to touch storage
+ * to steal it.
  *
  * A nonce cannot be a static header — it must differ per response, or it is just a password
  * an attacker can read off the page — so the policy moves out of next.config.ts and is built

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,7 +85,7 @@
         "@eslint/eslintrc": "^3.3.3",
         "@mdx-js/loader": "^3.1.1",
         "@next/mdx": "^16.2.11",
-        "@playwright/test": "^1.58.1",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.1.9",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -20,10 +20,17 @@ export default defineConfig({
     ],
 
     webServer: {
-        command: "npm run dev",
+        // Dev mode compiles each route on-demand, on first visit — the first test to hit a
+        // given route pays that compile latency inline, which is what made
+        // "starting an analysis" flake in CI (its own page snapshot showed Next's dev
+        // overlay still reading "Compiling..." at the moment of the failed assertion). A
+        // production build has every route pre-compiled, so CI runs against `build && start`
+        // instead; local runs keep `dev` for fast iteration, where reuseExistingServer means
+        // this rarely even launches a fresh server.
+        command: process.env.CI ? "npm run build && npm run start" : "npm run dev",
         url: baseURL,
         reuseExistingServer: !process.env.CI,
-        timeout: 120_000,
+        timeout: process.env.CI ? 240_000 : 120_000,
         env: {
             // Every request these specs make is mocked via page.route (see tests/e2e/mocks.ts).
             // Same-origin, deliberately: a cross-origin NEXT_PUBLIC_BACKEND_URL makes these
@@ -36,6 +43,9 @@ export default defineConfig({
             // returns its HTML 404 — a JSON parse error, not a silent pass — so it still can't
             // reach a real backend even if a developer's frontend/.env points at one.
             NEXT_PUBLIC_BACKEND_URL: baseURL,
+            // `next start` has no equivalent of `dev`'s hardcoded `-p 3001` — it needs this
+            // to bind the same port `baseURL` points at.
+            PORT: String(PORT),
         },
     },
 })

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,45 +1,36 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test"
 
-/**
- * Playwright configuration for SRA Frontend E2E tests.
- */
+const PORT = 3001
+const baseURL = `http://localhost:${PORT}`
+
 export default defineConfig({
-    testDir: './tests/e2e',
+    testDir: "./tests/e2e",
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
-    retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
-    reporter: 'html',
+    retries: process.env.CI ? 1 : 0,
+    reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+
     use: {
-        baseURL: 'http://localhost:3001',
-        trace: 'on-first-retry',
-        screenshot: 'only-on-failure',
+        baseURL,
+        trace: "on-first-retry",
     },
+
     projects: [
-        {
-            name: 'chromium',
-            use: { ...devices['Desktop Chrome'] },
-        },
-        {
-            name: 'firefox',
-            use: { ...devices['Desktop Firefox'] },
-        },
-        {
-            name: 'webkit',
-            use: { ...devices['Desktop Safari'] },
-        },
+        { name: "chromium", use: { ...devices["Desktop Chrome"] } },
     ],
+
     webServer: {
-        command: 'pnpm run dev',
-        url: 'http://localhost:3001',
+        command: "npm run dev",
+        url: baseURL,
         reuseExistingServer: !process.env.CI,
-        timeout: 300 * 1000,
+        timeout: 120_000,
         env: {
-            // Scoped via Playwright's own `env` (only the spawned dev-server child
-            // process for this E2E run, not the whole shell/other processes) instead of
-            // `set VAR=val && cmd`, which is Windows-only shell syntax and silently
-            // failed to set anything on Linux/Mac CI runners anyway.
-            NODE_TLS_REJECT_UNAUTHORIZED: '0',
+            // Every request these specs make is mocked via page.route (see tests/e2e/mocks.ts).
+            // Pointing this at an address nothing listens on means any request a spec forgot to
+            // mock fails loudly (connection refused) instead of silently reaching a real
+            // backend — which matters here specifically because a developer's real
+            // frontend/.env often points NEXT_PUBLIC_BACKEND_URL at a live deployment.
+            NEXT_PUBLIC_BACKEND_URL: "http://127.0.0.1:65535",
         },
     },
-});
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -26,11 +26,16 @@ export default defineConfig({
         timeout: 120_000,
         env: {
             // Every request these specs make is mocked via page.route (see tests/e2e/mocks.ts).
-            // Pointing this at an address nothing listens on means any request a spec forgot to
-            // mock fails loudly (connection refused) instead of silently reaching a real
-            // backend — which matters here specifically because a developer's real
-            // frontend/.env often points NEXT_PUBLIC_BACKEND_URL at a live deployment.
-            NEXT_PUBLIC_BACKEND_URL: "http://127.0.0.1:65535",
+            // Same-origin, deliberately: a cross-origin NEXT_PUBLIC_BACKEND_URL makes these
+            // fetch() calls subject to CORS, and route.fulfill()'s mocked response still has
+            // to satisfy the browser's CORS check like a real cross-origin response would — a
+            // mock with no Access-Control-Allow-Origin header gets silently blocked, and the
+            // app's own .catch() swallows it as an ordinary failed request. Same-origin sidesteps
+            // that entirely. A spec that forgets to mock something still fails loudly: the
+            // request lands on this app's own router, which has no matching API route and
+            // returns its HTML 404 — a JSON parse error, not a silent pass — so it still can't
+            // reach a real backend even if a developer's frontend/.env points at one.
+            NEXT_PUBLIC_BACKEND_URL: baseURL,
         },
     },
 })

--- a/frontend/tests/e2e/analysis.spec.ts
+++ b/frontend/tests/e2e/analysis.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page } from "@playwright/test"
+import { mockAuth, mockProjectsList, mockRecentAnalyses, MOCK_USER } from "./mocks"
+
+const json = (body: unknown, status = 200) => ({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+})
+
+/** A single active Gemini key is enough for the composer to leave its "no keys" state and
+ *  populate a default model — see buildModelOptions in lib/models.ts. */
+async function mockProviderKeys(page: Page) {
+    await page.route("**/settings/provider-keys", (route) =>
+        route.fulfill(json({ success: true, data: [{ provider: "GEMINI", isActive: true, availableModels: null }] }))
+    )
+    await page.route("**/settings/model-quota", (route) => route.fulfill(json({ success: true, data: [] })))
+}
+
+async function signIn(page: Page) {
+    await page.goto("/auth/login")
+    await page.locator("#email").fill(MOCK_USER.email)
+    await page.locator("#password").fill("correct-horse-battery-staple")
+    await page.getByRole("button", { name: "Sign in", exact: true }).click()
+    await expect(page).toHaveURL(/\/projects$/)
+}
+
+test.describe("starting an analysis", () => {
+    test("submits a brief and lands on the draft review screen", async ({ page }) => {
+        await mockAuth(page)
+        await mockRecentAnalyses(page)
+        await mockProjectsList(page, [])
+        await mockProviderKeys(page)
+
+        await signIn(page)
+
+        const analysisId = "an_e2e_0001"
+        const draftData = {
+            details: {
+                projectName: {
+                    content: "E2E Password Reset",
+                    metadata: { section_id: "1", subsection_id: "1.1", domain_type: "web", is_required: true, completion_status: "complete" },
+                },
+                fullDescription: {
+                    content: "Users need to reset their password via an emailed link that expires after 30 minutes.",
+                    metadata: { section_id: "1", subsection_id: "1.2", domain_type: "web", is_required: true, completion_status: "complete" },
+                },
+            },
+        }
+
+        await page.route("**/analyze", (route) => {
+            if (route.request().method() === "POST") {
+                return route.fulfill(json({ success: true, data: { id: analysisId, status: "draft" } }))
+            }
+            return route.fallback()
+        })
+        await page.route(`**/analyze/${analysisId}/validate`, (route) =>
+            route.fulfill(json({
+                success: true,
+                data: { metadata: { validationResult: { validation_status: "PASS", issues: [] } } },
+            }))
+        )
+        await page.route(`**/analyze/${analysisId}`, (route) => {
+            if (route.request().method() === "GET") {
+                return route.fulfill(json({
+                    success: true,
+                    data: {
+                        id: analysisId,
+                        status: "DRAFT",
+                        isFinalized: false,
+                        metadata: { status: "DRAFT", draftData },
+                    },
+                }))
+            }
+            return route.fallback()
+        })
+
+        await page.goto("/analysis/new")
+        await page
+            .getByPlaceholder("Describe what the system should do…")
+            .fill("Users need to reset their password via an emailed link that expires after 30 minutes.")
+        await page.getByRole("button", { name: "Start analysis" }).click()
+
+        await expect(page).toHaveURL(new RegExp(`/analysis/${analysisId}$`))
+    })
+})

--- a/frontend/tests/e2e/analysis.spec.ts
+++ b/frontend/tests/e2e/analysis.spec.ts
@@ -24,6 +24,19 @@ async function signIn(page: Page) {
     await expect(page).toHaveURL(/\/projects$/)
 }
 
+/** Reaches the analysis composer via the in-app button, not `page.goto`.
+ *
+ *  The access token lives only in memory (see auth-context.tsx) — a real page.goto is a hard
+ *  navigation that reloads the whole app from zero, and the fresh load's silent
+ *  refresh-via-cookie has no real cookie to redeem in this mocked test, so it silently wipes
+ *  the token before the composer ever gets a chance to submit. Clicking through, like an
+ *  actual user, keeps the same in-memory session across the client-side route change.
+ */
+async function goToNewAnalysis(page: Page) {
+    await page.getByRole("button", { name: "New analysis" }).first().click()
+    await expect(page).toHaveURL(/\/analysis\/new$/)
+}
+
 test.describe("starting an analysis", () => {
     test("submits a brief and lands on the draft review screen", async ({ page }) => {
         await mockAuth(page)
@@ -74,13 +87,7 @@ test.describe("starting an analysis", () => {
             return route.fallback()
         })
 
-        await page.goto("/analysis/new")
-        // This composer is one of the heavier client components in the app (sliders,
-        // popovers, a model picker) — clicking before it finishes hydrating is a real click
-        // on a real, visible button that silently does nothing, since no React handler is
-        // attached yet. Waiting for the network to go idle gives every code-split chunk a
-        // chance to load and hydrate before any interaction.
-        await page.waitForLoadState("networkidle")
+        await goToNewAnalysis(page)
         await page
             .getByPlaceholder("Describe what the system should do…")
             .fill("Users need to reset their password via an emailed link that expires after 30 minutes.")

--- a/frontend/tests/e2e/analysis.spec.ts
+++ b/frontend/tests/e2e/analysis.spec.ts
@@ -75,10 +75,18 @@ test.describe("starting an analysis", () => {
         })
 
         await page.goto("/analysis/new")
+        // This composer is one of the heavier client components in the app (sliders,
+        // popovers, a model picker) — clicking before it finishes hydrating is a real click
+        // on a real, visible button that silently does nothing, since no React handler is
+        // attached yet. Waiting for the network to go idle gives every code-split chunk a
+        // chance to load and hydrate before any interaction.
+        await page.waitForLoadState("networkidle")
         await page
             .getByPlaceholder("Describe what the system should do…")
             .fill("Users need to reset their password via an emailed link that expires after 30 minutes.")
-        await page.getByRole("button", { name: "Start analysis" }).click()
+        const startButton = page.getByRole("button", { name: "Start analysis" })
+        await expect(startButton).toBeEnabled()
+        await startButton.click()
 
         await expect(page).toHaveURL(new RegExp(`/analysis/${analysisId}$`))
     })

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -33,7 +33,9 @@ test.describe("authentication", () => {
             route.fulfill({
                 status: 401,
                 contentType: "application/json",
-                body: JSON.stringify({ message: "Invalid email or password" }),
+                // The login page's catch reads `data.error`, not `data.message` — unlike
+                // every other auth endpoint mocked in this suite.
+                body: JSON.stringify({ error: "Invalid email or password" }),
             })
         )
 

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test"
+import { mockAuth, mockProjectsList, MOCK_USER } from "./mocks"
+
+test.describe("authentication", () => {
+    test("logs in and lands on the projects list", async ({ page }) => {
+        await mockAuth(page)
+        await mockProjectsList(page, [])
+
+        await page.goto("/auth/login")
+        await page.locator("#email").fill(MOCK_USER.email)
+        await page.locator("#password").fill("correct-horse-battery-staple")
+        await page.getByRole("button", { name: "Sign in", exact: true }).click()
+
+        await expect(page).toHaveURL(/\/projects$/)
+    })
+
+    test("signs up and lands on the projects list", async ({ page }) => {
+        await mockAuth(page)
+        await mockProjectsList(page, [])
+
+        await page.goto("/auth/signup")
+        await page.locator("#fullname").fill(MOCK_USER.name)
+        await page.locator("#email").fill(MOCK_USER.email)
+        await page.locator("#password").fill("correct-horse-battery-staple")
+        await page.getByRole("button", { name: "Sign up", exact: true }).click()
+
+        await expect(page).toHaveURL(/\/projects$/)
+    })
+
+    test("shows an error toast on invalid credentials without navigating", async ({ page }) => {
+        await mockAuth(page)
+        await page.route("**/api/auth/login", (route) =>
+            route.fulfill({
+                status: 401,
+                contentType: "application/json",
+                body: JSON.stringify({ message: "Invalid email or password" }),
+            })
+        )
+
+        await page.goto("/auth/login")
+        await page.locator("#email").fill(MOCK_USER.email)
+        await page.locator("#password").fill("wrong-password")
+        await page.getByRole("button", { name: "Sign in", exact: true }).click()
+
+        await expect(page.getByText("Invalid email or password")).toBeVisible()
+        await expect(page).toHaveURL(/\/auth\/login$/)
+    })
+})

--- a/frontend/tests/e2e/mocks.ts
+++ b/frontend/tests/e2e/mocks.ts
@@ -41,6 +41,14 @@ export async function mockAuth(page: Page) {
 /** Project/analysis/settings endpoints call NEXT_PUBLIC_BACKEND_URL directly (cross-origin in dev). */
 export async function mockProjectsList(page: Page, projects: unknown[] = []) {
     await page.route("**/projects", (route) => {
+        // "**/projects" also matches this app's own /projects page navigation (the
+        // post-login redirect target), not just the backend's list-projects call — CI runs
+        // with NEXT_PUBLIC_BACKEND_URL same-origin (see playwright.config.ts), so the two are
+        // indistinguishable by URL alone. Only intercept the API fetch; let the document
+        // request through to Next's own router.
+        if (route.request().resourceType() === "document") {
+            return route.fallback()
+        }
         if (route.request().method() === "GET") {
             return route.fulfill(json({ success: true, data: projects }))
         }

--- a/frontend/tests/e2e/mocks.ts
+++ b/frontend/tests/e2e/mocks.ts
@@ -1,0 +1,72 @@
+import type { Page } from "@playwright/test"
+
+/**
+ * Every request these specs make is mocked at the browser network layer — no live backend
+ * is involved. This matters beyond speed/determinism: a developer's real frontend/.env
+ * commonly points NEXT_PUBLIC_BACKEND_URL at a live deployment (see playwright.config.ts),
+ * so an un-mocked request must fail loudly, never fall through to production.
+ */
+
+export const MOCK_USER = {
+    id: "usr_e2e_0001",
+    email: "e2e@example.com",
+    name: "E2E Test User",
+}
+
+export const MOCK_TOKEN = "e2e-mock-access-token"
+
+const json = (body: unknown, status = 200) => ({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+})
+
+/** Auth endpoints go through the same-origin Next.js proxy (/api/auth/*). */
+export async function mockAuth(page: Page) {
+    await page.route("**/api/auth/login", (route) =>
+        route.fulfill(json({ user: MOCK_USER, token: MOCK_TOKEN }))
+    )
+    await page.route("**/api/auth/signup", (route) =>
+        route.fulfill(json({ user: MOCK_USER, token: MOCK_TOKEN }, 201))
+    )
+    // Mount-time silent refresh (auth-context.tsx) — no cookie exists in a fresh browser
+    // context, so the real backend would 401 anyway; mocking it the same way keeps every
+    // spec's console free of an expected-but-noisy failed request.
+    await page.route("**/api/auth/refresh", (route) =>
+        route.fulfill(json({ message: "No active session" }, 401))
+    )
+    await page.route("**/api/auth/logout", (route) => route.fulfill(json({ message: "Logged out" })))
+}
+
+/** Project/analysis/settings endpoints call NEXT_PUBLIC_BACKEND_URL directly (cross-origin in dev). */
+export async function mockProjectsList(page: Page, projects: unknown[] = []) {
+    await page.route("**/projects", (route) => {
+        if (route.request().method() === "GET") {
+            return route.fulfill(json({ success: true, data: projects }))
+        }
+        return route.fallback()
+    })
+}
+
+/** The projects list page's "recent activity" rail — a separate SWR call to GET /analyze. */
+export async function mockRecentAnalyses(page: Page, items: unknown[] = []) {
+    await page.route("**/analyze", (route) => {
+        if (route.request().method() === "GET") {
+            return route.fulfill(json({ success: true, data: items }))
+        }
+        return route.fallback()
+    })
+}
+
+export function makeProject(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "proj_e2e_0001",
+        name: "E2E Test Project",
+        description: "Created by a Playwright spec",
+        userId: MOCK_USER.id,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        _count: { analyses: 0 },
+        ...overrides,
+    }
+}

--- a/frontend/tests/e2e/project.spec.ts
+++ b/frontend/tests/e2e/project.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test"
+import { mockAuth, mockProjectsList, mockRecentAnalyses, makeProject } from "./mocks"
+
+/** Signs in and lands on /projects — every spec in this file needs a session first. */
+async function signIn(page: import("@playwright/test").Page) {
+    await page.goto("/auth/login")
+    await page.locator("#email").fill("e2e@example.com")
+    await page.locator("#password").fill("correct-horse-battery-staple")
+    await page.getByRole("button", { name: "Sign in", exact: true }).click()
+    await expect(page).toHaveURL(/\/projects$/)
+}
+
+test.describe("projects", () => {
+    test("creates a project and navigates into it", async ({ page }) => {
+        await mockAuth(page)
+        await mockRecentAnalyses(page)
+        await mockProjectsList(page, [])
+
+        await signIn(page)
+
+        const created = makeProject({ name: "New E2E Project" })
+        await page.route("**/projects", (route) => {
+            if (route.request().method() === "POST") {
+                return route.fulfill({
+                    status: 201,
+                    contentType: "application/json",
+                    body: JSON.stringify({ success: true, data: created }),
+                })
+            }
+            return route.fallback()
+        })
+
+        // Two "New project" buttons render when the list is empty (header + empty-state
+        // prompt) — .first() takes the always-present header one.
+        await page.getByRole("button", { name: "New project" }).first().click()
+        await page.getByPlaceholder("Name your project…").fill("New E2E Project")
+        await page.getByRole("button", { name: "Create" }).click()
+
+        await expect(page.getByText("New E2E Project")).toBeVisible()
+
+        // Mock the detail page this card links to before following it.
+        await page.route(`**/projects/${created.id}`, (route) => {
+            if (route.request().method() === "GET") {
+                return route.fulfill({
+                    status: 200,
+                    contentType: "application/json",
+                    body: JSON.stringify({ success: true, data: { ...created, analyses: [] } }),
+                })
+            }
+            return route.fallback()
+        })
+
+        await page.getByText("New E2E Project").click()
+        await expect(page).toHaveURL(new RegExp(`/projects/${created.id}$`))
+    })
+
+    test("lists existing projects on load", async ({ page }) => {
+        await mockAuth(page)
+        await mockRecentAnalyses(page)
+        const existing = makeProject({ name: "Already There" })
+        await mockProjectsList(page, [existing])
+
+        await signIn(page)
+
+        await expect(page.getByText("Already There")).toBeVisible()
+    })
+})

--- a/frontend/tests/e2e/project.spec.ts
+++ b/frontend/tests/e2e/project.spec.ts
@@ -36,7 +36,11 @@ test.describe("projects", () => {
         await page.getByPlaceholder("Name your project…").fill("New E2E Project")
         await page.getByRole("button", { name: "Create" }).click()
 
-        await expect(page.getByText("New E2E Project")).toBeVisible()
+        // The shell layout's sidebar also lists projects by name (as a plain button, not a
+        // heading) — getByText would match both it and the card below, so scope to the card's
+        // heading specifically.
+        const card = page.getByRole("heading", { name: "New E2E Project" })
+        await expect(card).toBeVisible()
 
         // Mock the detail page this card links to before following it.
         await page.route(`**/projects/${created.id}`, (route) => {
@@ -50,7 +54,7 @@ test.describe("projects", () => {
             return route.fallback()
         })
 
-        await page.getByText("New E2E Project").click()
+        await card.click()
         await expect(page).toHaveURL(new RegExp(`/projects/${created.id}$`))
     })
 
@@ -62,6 +66,7 @@ test.describe("projects", () => {
 
         await signIn(page)
 
-        await expect(page.getByText("Already There")).toBeVisible()
+        // Same sidebar-vs-card ambiguity as above — the sidebar shows this project too.
+        await expect(page.getByRole("heading", { name: "Already There" })).toBeVisible()
     })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,7 +420,7 @@ importers:
         specifier: ^16.2.11
         version: 16.2.11(@mdx-js/loader@3.1.1)
       '@playwright/test':
-        specifier: ^1.58.1
+        specifier: ^1.59.1
         version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4.1.9
@@ -12331,8 +12331,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -12354,7 +12354,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -12365,22 +12365,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12391,7 +12391,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Triaged all 21 open issues. 13 turned out to already be fixed, false, or in direct conflict with documented architecture — closed individually with an evidence-based comment on each (see issue list below). The remaining 3 genuine, in-scope issues are addressed here as separate commits.

## What's in this PR

1. **Move access tokens out of localStorage (#128)** — the JWT access token now lives only in React context state, restored on load by silently exchanging the httpOnly refresh cookie via `/auth/refresh`. Verified: full `auth-context.test.tsx` suite (8 tests) and the full frontend Vitest suite (88/88) pass; lint clean.

2. **Bruno API collection (#146)** — a version-controlled collection covering auth session lifecycle, project CRUD, the analysis enqueue/status/history contract, and provider-key listing, run against a real backend + Postgres (not mocked). Verified end-to-end locally against a throwaway pgvector Postgres and a `MOCK_AI`/`MOCK_QSTASH` backend instance — 15/15 requests, 18/18 tests, twice in a row (idempotency check). Wired into a new `api-collection.yml` CI workflow, reproduced locally against the exact same job sequence before committing.

3. **Playwright E2E scaffold (#147)** — auth (login/signup/invalid-credentials), project creation/listing, and starting an analysis through to the draft screen. Every request is mocked at the browser network layer; `playwright.config.ts` deliberately points the dev server at an address nothing listens on, so an unmocked request fails loudly rather than silently reaching a real deployment. **Caveat**: this session's environment could not complete a Chromium download (the extraction hung indefinitely after the zip itself downloaded fine — confirmed via `lsof`, not a transient timeout), so these specs are verified by careful reading against the current page source (catching 2 real bugs that way: an `aria-label` substring collision with the OAuth buttons, and a duplicate "New project" button when the list is empty) rather than an actual run. Worth an early, deliberate CI run before relying on this suite.

## Issues closed as already-resolved / false / conflicting with architecture

- #118 Helmet.js — already mounted in `app.js`
- #131 frontend `.env.example` — already exists
- #117 terraform.tfvars secrets — never tracked, gitignored; JWT_SECRET already enforced ≥32 bytes
- #136 SSE streaming — already implemented
- #137 prompt compaction — already used by ChatAgent/ReviewerAgent
- #138 JSON/Mermaid auto-repair — already implemented
- #139 BYOK rate-limit fallback router — already implemented, quota-aware
- #140 pgvector — already native (not in-memory)
- #141 QStash resumable pipeline — already implemented
- #142 Inngest — redundant with the existing QStash/checkpoint system
- #144 Ollama local model adapter — contradicts CLAUDE.md: "Do not reintroduce the removed self-hosted model track"
- #127 nginx TLS/HSTS — headers already present; TLS is deliberately deferred to an edge terminator per an existing code comment
- #129 terraform local state backend — intentional dev default; needs a real S3/Terraform Cloud target to switch for real

## Left open (backlog, not addressed here)

#135 (semantic pipeline cache), #143 (Spectral/CodeRabbit API linting), #145 (Meilisearch), #148 (Snyk), #149 (Grafana/Prometheus) — legitimate feature/tooling requests, several needing external accounts/tokens or infra decisions outside this pass's scope.

## Test plan

- [x] `pnpm --filter frontend test` — 88/88 passing
- [x] `pnpm --filter frontend lint` / `tsc --noEmit` — clean
- [x] Bruno collection run twice against a fresh local pgvector Postgres + `MOCK_AI`/`MOCK_QSTASH` backend — 15/15 requests, 18/18 tests both times
- [x] `pnpm install --frozen-lockfile` — clean (pnpm 9, matching CI's pin)
- [ ] Playwright specs — not executable in this session (see caveat above); should run in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved session restoration by keeping access tokens in memory and using secure refresh-cookie exchange.
  * Enhanced handling of silent refreshes and expired sessions.

* **Testing**
  * Added end-to-end coverage for authentication, projects, and analysis workflows.
  * Added API checks for health, authentication, projects, analysis, settings, and logout.
  * Added automated CI execution for browser and API test suites.

* **Documentation**
  * Documented API collection setup, coverage, execution, environments, and CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->