### PR TITLE
Fix gitleaks false positive on CI-only mock secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+title = "SRA gitleaks config"
+
+[extend]
+useDefault = true
+
+# .github/workflows/api-collection.yml deliberately hardcodes JWT_SECRET/ENCRYPTION_KEY as
+# fixed, non-secret stub values for the bruno-run CI job: that job runs with MOCK_AI=true and
+# MOCK_QSTASH=true, so nothing behind these values is real — they exist only to satisfy
+# env.js's zod schema (minimum-length checks), not to authenticate against anything. gitleaks'
+# default generic-api-key rule flags them on entropy alone with no way to tell that apart from
+# a real secret, so they're allowlisted by their exact, publicly-known value rather than by
+# commit fingerprint (which would break every time this file is touched again).
+[allowlist]
+description = "Known non-secret CI stub values"
+regexes = [
+  '''ci-bruno-jwt-secret-at-least-32-characters-long''',
+  '''ci-bruno-encryption-key-16char''',
+]


### PR DESCRIPTION
## Summary
- Fixes #155 — the scheduled Secret Leak Detection scan was flagging `JWT_SECRET`/`ENCRYPTION_KEY` in `.github/workflows/api-collection.yml`'s `bruno-run` job (introduced in #154).
- Those are fixed, non-secret stub strings for a fully mocked CI job (`MOCK_AI=true`, `MOCK_QSTASH=true`) — they exist only to satisfy `env.js`'s zod schema length checks, not to authenticate against anything real. gitleaks' default `generic-api-key` rule can't distinguish that from an actual secret on entropy alone.
- Added `.gitleaks.toml` allowlisting those two exact known-safe strings (by value, not commit fingerprint, so it survives future edits to that file), while keeping the default gitleaks ruleset (`useDefault = true`) for everything else.

## Verification
Installed the real `gitleaks` binary locally and ran it against the actual repo history (699 commits) at the commit `security-audit.yml` originally flagged:
- Before: `leaks found: 2`
- After: `no leaks found`, exit code 0

## Test plan
- [x] `gitleaks detect --redact --exit-code=2` locally: 0 leaks, exit 0
- [ ] CI's `Secret Leak Detection` job (`security-audit.yml`) passes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added secret-scanning configuration for the project.
  * Allowlisted known non-sensitive CI placeholder values to reduce false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->