### PR TITLE
Sanitize AI error messages, add provider fallback, fix UI inconsistencies

### DIFF
--- a/backend/src/agents/BaseAgent.js
+++ b/backend/src/agents/BaseAgent.js
@@ -5,6 +5,7 @@ import { parseQuotaFailure, isPerDayQuota } from '../utils/rateLimitHeaders.js';
 import { recordUsage, recordExhausted } from '../services/providers/modelQuotaService.js';
 import { resolveOutputTokenLimits, clampOutputTokens } from '../utils/llmGenerationConfig.js';
 import { getAdapter, DEFAULT_MODELS, normalizeProvider } from '../services/providers/index.js';
+import { selectNextFallbackModel } from '../services/providers/modelFallbackService.js';
 
 // One MOCK_AI answer, defined once so the streamed replay and the returned object cannot drift.
 const MOCK_JSON_RESPONSE = {
@@ -73,7 +74,7 @@ export class BaseAgent {
      */
     constructor(name, providerConfig = {}) {
         this.name = name;
-        const { provider, modelName, apiKey, inputTokenLimit, outputTokenLimit, userId } = providerConfig;
+        const { provider, modelName, apiKey, inputTokenLimit, outputTokenLimit, userId, allowModelFallback, fallbackModels } = providerConfig;
         // Whose key is being spent. Quota is tracked per user per model, so a run that
         // cannot say who it is for is simply not counted rather than counted against someone.
         this.userId = userId || null;
@@ -85,6 +86,11 @@ export class BaseAgent {
         this.inputTokenLimit = inputTokenLimit;
         this.outputTokenLimit = outputTokenLimit;
         this.tokenLimits = resolveOutputTokenLimits(outputTokenLimit);
+        // User-approved ordered fallback chain (see callLLM) — a call that keeps failing
+        // against this provider switches to the next approved one instead of exhausting
+        // its retry budget against a provider that predictably won't recover in time.
+        this.allowModelFallback = allowModelFallback === true;
+        this.fallbackModels = fallbackModels;
         this._adapter = null; // lazily constructed — see getAdapter() below, so a missing
         // non-Gemini key only throws when a real (non-mocked) LLM call is actually made
     }
@@ -142,11 +148,15 @@ export class BaseAgent {
             new Promise((_, reject) => setTimeout(() => reject(new Error("AI Request Timeout")), ms))
         ]);
 
-        const adapter = this.getAdapter();
+        // Seeded with the starting provider/model so a fallback never re-offers the one
+        // that just failed — refetched fresh each loop iteration below, since a fallback
+        // mid-call swaps this.provider/this.modelName/this._apiKey in place.
+        const attempted = [{ provider: this.provider, modelName: this.modelName }];
 
         while (true) {
             // Set when the timeout wins the race below, so an abandoned stream stops consuming.
             let streamAbandoned = false;
+            const adapter = this.getAdapter();
 
             try {
                 const request = {
@@ -198,7 +208,7 @@ export class BaseAgent {
             } catch (error) {
                 streamAbandoned = true;
                 const isTimeout = error.message === "AI Request Timeout";
-                const { isRateLimit, isServerError } = isTimeout ? {} : adapter.classifyError(error);
+                const { isRateLimit, isServerError, isAuthError } = isTimeout ? {} : adapter.classifyError(error);
 
                 // A per-day cap reads as a rate limit but never clears inside one run, so
                 // retrying only spends the time budget the pipeline still needs. Fail now
@@ -226,13 +236,16 @@ export class BaseAgent {
                     throw buildExhaustedQuotaError(error, this.modelName);
                 }
 
-                if ((isRateLimit || isServerError || isTimeout) && attempt < retries) {
+                // Windowed rate limits and timeouts back off against the same provider
+                // first — a per-minute window clears in seconds, and a slow call may
+                // already be mid-generation, so switching provider mid-flight buys nothing.
+                if ((isRateLimit || isTimeout) && attempt < retries) {
                     const jitter = delay * 0.2 * (Math.random() * 2 - 1);
                     const finalDelay = Math.max(1000, delay + jitter);
 
                     logger.warn({
                         msg: `[${this.name}] LLM Retry`,
-                        reason: isTimeout ? 'Timeout' : (isRateLimit ? 'Rate Limit' : 'Server Error'),
+                        reason: isTimeout ? 'Timeout' : 'Rate Limit',
                         provider: this.provider,
                         attempt: attempt + 1,
                         retries,
@@ -245,14 +258,75 @@ export class BaseAgent {
                     await new Promise(resolve => setTimeout(resolve, finalDelay));
                     delay *= 2;
                     attempt++;
-                } else {
-                    const isFetchFailed = error.message?.includes("fetch failed");
-                    logger.error({ msg: `[${this.name}] LLM Call Failed`, provider: this.provider, error: error.message });
-                    if (isFetchFailed) {
-                        logger.fatal(`[${this.name}] FATAL: Unable to reach ${this.provider} servers. Check network/proxy.`);
-                    }
-                    throw new Error(`${this.name} failed to generate content: ${error.message}`);
+                    continue;
                 }
+
+                // Overload/5xx, an auth error, or a rate limit whose same-provider retry
+                // budget is spent: prefer the user's next approved model over hammering
+                // (or, for auth, uselessly repeating a call against) the same provider —
+                // an overloaded provider is unlikely to recover in the next few seconds,
+                // and a rejected key never will.
+                if ((isServerError || isAuthError || isRateLimit) && this.allowModelFallback) {
+                    const candidate = await selectNextFallbackModel(
+                        this.userId,
+                        { allowModelFallback: true, fallbackModels: this.fallbackModels, modelProvider: this.provider, modelName: this.modelName },
+                        attempted
+                    ).catch((lookupErr) => {
+                        logger.warn({ msg: `[${this.name}] Fallback lookup failed`, error: lookupErr.message });
+                        return null;
+                    });
+
+                    if (candidate) {
+                        logger.warn({
+                            msg: `[${this.name}] Falling back to next approved provider`,
+                            from: `${this.provider}:${this.modelName}`,
+                            to: `${candidate.provider}:${candidate.modelName}`,
+                            reason: isServerError ? 'server_error' : isAuthError ? 'auth_error' : 'rate_limit'
+                        });
+                        attempted.push({ provider: candidate.provider, modelName: candidate.modelName });
+                        this.provider = candidate.provider;
+                        this.modelName = candidate.modelName;
+                        this._apiKey = candidate.apiKey;
+                        this.inputTokenLimit = candidate.inputTokenLimit;
+                        this.outputTokenLimit = candidate.outputTokenLimit;
+                        this.tokenLimits = resolveOutputTokenLimits(candidate.outputTokenLimit);
+                        this._adapter = null; // rebuilt by getAdapter() at the top of the next iteration
+                        options.onStream?.({ type: 'reset' });
+                        attempt = 0;
+                        delay = initialDelay;
+                        continue;
+                    }
+                }
+
+                // Last resort for a server error when no fallback is configured/available —
+                // preserves today's same-provider retry behavior for single-key users.
+                if (isServerError && attempt < retries) {
+                    const jitter = delay * 0.2 * (Math.random() * 2 - 1);
+                    const finalDelay = Math.max(1000, delay + jitter);
+
+                    logger.warn({
+                        msg: `[${this.name}] LLM Retry`,
+                        reason: 'Server Error',
+                        provider: this.provider,
+                        attempt: attempt + 1,
+                        retries,
+                        nextRetryIn: Math.round(finalDelay)
+                    });
+
+                    options.onStream?.({ type: 'reset' });
+
+                    await new Promise(resolve => setTimeout(resolve, finalDelay));
+                    delay *= 2;
+                    attempt++;
+                    continue;
+                }
+
+                const isFetchFailed = error.message?.includes("fetch failed");
+                logger.error({ msg: `[${this.name}] LLM Call Failed`, provider: this.provider, error: error.message });
+                if (isFetchFailed) {
+                    logger.fatal(`[${this.name}] FATAL: Unable to reach ${this.provider} servers. Check network/proxy.`);
+                }
+                throw new Error(`${this.name} failed to generate content: ${error.message}`);
             }
         }
     }

--- a/backend/src/controllers/analysisController.js
+++ b/backend/src/controllers/analysisController.js
@@ -458,8 +458,12 @@ export const chatStream = async (req, res, next) => {
         });
         send({ type: 'done', newAnalysisId: result.newAnalysisId });
     } catch (error) {
-        logger.error({ msg: '[chatStream] Failed', error: error.message, stack: error.stack });
-        send({ type: 'error', message: sanitizeError(error).message });
+        // Raw provider error text isn't logged here — some SDKs echo a masked-but-present
+        // key fragment into their error message on an auth failure, and pino's redaction
+        // only scrubs known field paths, not substrings inside free text (see logger.js).
+        const sanitized = sanitizeError(error);
+        logger.error({ msg: '[chatStream] Failed', code: sanitized.code, statusCode: sanitized.statusCode });
+        send({ type: 'error', message: sanitized.message });
     } finally {
         if (!aborted) res.end();
     }
@@ -783,8 +787,9 @@ export const validateAnalysis = async (req, res, next) => {
                 await resolveProviderForUser(req.user.userId, analysis.metadata?.promptSettings)
             );
         } catch (validationErr) {
-            logger.error({ msg: "AI Validation Failed", error: validationErr.message, stack: validationErr.stack });
+            // Raw provider error text isn't logged — see the note in chatStream's catch.
             const sanitized = sanitizeError(validationErr, { providerHint: analysis.metadata?.promptSettings?.modelProvider });
+            logger.error({ msg: "AI Validation Failed", code: sanitized.code, statusCode: sanitized.statusCode });
             const friendlyTitle = sanitized.code === ErrorCodes.SERVICE_UNAVAILABLE ? 'AI Service Busy'
                 : sanitized.code === ErrorCodes.RATE_LIMIT_EXCEEDED || sanitized.code === ErrorCodes.AI_QUOTA_EXCEEDED ? 'AI Quota Exceeded'
                     : 'AI Validation Service Unavailable';
@@ -877,8 +882,9 @@ export const repairDiagram = async (req, res, next) => {
         );
         return successResponse(res, { code: repairedCode });
     } catch (error) {
-        logger.error({ msg: '[repairDiagram] Failed', error: error.message, stack: error.stack });
+        // Raw provider error text isn't logged — see the note in chatStream's catch.
         const sanitized = sanitizeError(error, { providerHint: req.body?.settings?.modelProvider });
+        logger.error({ msg: '[repairDiagram] Failed', code: sanitized.code, statusCode: sanitized.statusCode });
         return res.status(sanitized.statusCode).json({ success: false, error: sanitized.message });
     }
 };

--- a/backend/src/controllers/analysisController.js
+++ b/backend/src/controllers/analysisController.js
@@ -16,6 +16,8 @@ import { successResponse } from '../utils/response.js';
 import logger from '../config/logger.js';
 import { createNextVersion } from '../services/versioning.js';
 import { resolveProviderForUser, asAiSettings } from '../services/providers/providerKeyService.js';
+import { sanitizeError } from '../utils/errorSanitizer.js';
+import { ErrorCodes } from '../utils/errorCodes.js';
 
 export const analyze = async (req, res, next) => {
     try {
@@ -456,8 +458,8 @@ export const chatStream = async (req, res, next) => {
         });
         send({ type: 'done', newAnalysisId: result.newAnalysisId });
     } catch (error) {
-        logger.error({ msg: '[chatStream] Failed', error: error.message });
-        send({ type: 'error', message: error.message });
+        logger.error({ msg: '[chatStream] Failed', error: error.message, stack: error.stack });
+        send({ type: 'error', message: sanitizeError(error).message });
     } finally {
         if (!aborted) res.end();
     }
@@ -781,23 +783,17 @@ export const validateAnalysis = async (req, res, next) => {
                 await resolveProviderForUser(req.user.userId, analysis.metadata?.promptSettings)
             );
         } catch (validationErr) {
-            logger.error({ msg: "AI Validation Failed", error: validationErr.message });
-            let friendlyMessage = validationErr.message;
-            let friendlyTitle = 'AI Validation Service Unavailable';
-
-            if (validationErr.message.includes('503') || validationErr.message.toLowerCase().includes('service unavailable') || validationErr.message.toLowerCase().includes('overloaded')) {
-                friendlyTitle = 'AI Service Busy';
-                friendlyMessage = 'The AI is currently processing many requests. Please wait a moment and try again.';
-            } else if (validationErr.message.includes('429') || validationErr.message.includes('Quota exceeded') || validationErr.message.toLowerCase().includes('quota')) {
-                friendlyTitle = 'AI Quota Exceeded';
-                friendlyMessage = 'The AI service is currently rate-limited. Please retry in 30-60 seconds.';
-            }
+            logger.error({ msg: "AI Validation Failed", error: validationErr.message, stack: validationErr.stack });
+            const sanitized = sanitizeError(validationErr, { providerHint: analysis.metadata?.promptSettings?.modelProvider });
+            const friendlyTitle = sanitized.code === ErrorCodes.SERVICE_UNAVAILABLE ? 'AI Service Busy'
+                : sanitized.code === ErrorCodes.RATE_LIMIT_EXCEEDED || sanitized.code === ErrorCodes.AI_QUOTA_EXCEEDED ? 'AI Quota Exceeded'
+                    : 'AI Validation Service Unavailable';
 
             validationResult = {
                 validation_status: 'SERVICE_ERROR',
                 service_error: {
                     title: friendlyTitle,
-                    message: friendlyMessage
+                    message: sanitized.message
                 },
                 issues: [],
                 clarification_questions: []
@@ -881,13 +877,9 @@ export const repairDiagram = async (req, res, next) => {
         );
         return successResponse(res, { code: repairedCode });
     } catch (error) {
-        if (error.message.includes("429") || error.status === 429) {
-            return res.status(503).json({
-                success: false,
-                error: "AI Service is currently busy (Rate Limit). Please try again in a few moments."
-            });
-        }
-        next(error);
+        logger.error({ msg: '[repairDiagram] Failed', error: error.message, stack: error.stack });
+        const sanitized = sanitizeError(error, { providerHint: req.body?.settings?.modelProvider });
+        return res.status(sanitized.statusCode).json({ success: false, error: sanitized.message });
     }
 };
 

--- a/backend/src/middleware/errorMiddleware.js
+++ b/backend/src/middleware/errorMiddleware.js
@@ -9,7 +9,11 @@ export const errorHandler = (err, req, res, next) => {
     const sanitized = sanitizeError(err);
     const statusCode = err.statusCode || sanitized.statusCode || 500;
     const message = sanitized.message;
-    const errorCode = err.code || sanitized.code || ErrorCodes.INTERNAL_ERROR;
+    // sanitized.code already preserves err.code for our own deliberately-thrown errors
+    // (statusCode < 500) — using err.code here too would let an arbitrary third-party
+    // error code (e.g. a raw Prisma or provider SDK code) leak past the canonical
+    // ErrorCodes contract the frontend pattern-matches on.
+    const errorCode = sanitized.code || ErrorCodes.INTERNAL_ERROR;
 
     // Structured logging via pino (was console.error, which bypassed the logger and its
     // redaction/formatting). 5xx are logged at error level with the stack; expected 4xx

--- a/backend/src/middleware/errorMiddleware.js
+++ b/backend/src/middleware/errorMiddleware.js
@@ -1,10 +1,15 @@
 import { ErrorCodes } from '../utils/errorCodes.js';
+import { sanitizeError } from '../utils/errorSanitizer.js';
 import logger from '../config/logger.js';
 
 export const errorHandler = (err, req, res, next) => {
-    const statusCode = err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-    const errorCode = err.code || (statusCode === 429 ? ErrorCodes.RATE_LIMIT_EXCEEDED : ErrorCodes.INTERNAL_ERROR);
+    // sanitizeError trusts any message already attached to a statusCode < 500 (our own
+    // deliberately-thrown, client-actionable errors) and only rewrites raw/5xx/unclassified
+    // provider text — so this is safe to apply to every error that reaches this handler.
+    const sanitized = sanitizeError(err);
+    const statusCode = err.statusCode || sanitized.statusCode || 500;
+    const message = sanitized.message;
+    const errorCode = err.code || sanitized.code || ErrorCodes.INTERNAL_ERROR;
 
     // Structured logging via pino (was console.error, which bypassed the logger and its
     // redaction/formatting). 5xx are logged at error level with the stack; expected 4xx

--- a/backend/src/services/analysisService.js
+++ b/backend/src/services/analysisService.js
@@ -22,6 +22,7 @@ import { EvalService } from './knowledge/evalService.js';
 import { retrieveContext, formatRagContext } from './knowledge/ragService.js';
 import { createReviewSnapshot } from '../utils/promptCompaction.js';
 import { createCooldown } from '../utils/throttle.js';
+import { sanitizeError } from '../utils/errorSanitizer.js';
 const CACHE_TTL = 3600; // 1 hour in seconds
 
 // Gemini free-tier rate limits (requests/minute) are the reason for these — not
@@ -155,7 +156,11 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
         // userId rides along so every agent call can be attributed to the key it spends —
         // quota is tracked per user per model, which is what lets the picker say *which*
         // model is out and lets a failed run be resumed on a different one.
-        providerConfig = { provider, apiKey, modelName, inputTokenLimit, outputTokenLimit, userId };
+        providerConfig = {
+            provider, apiKey, modelName, inputTokenLimit, outputTokenLimit, userId,
+            allowModelFallback: settings?.allowModelFallback === true,
+            fallbackModels: settings?.fallbackModels
+        };
 
         // Provider-aware cooldown: the sleeps below exist only to respect Gemini free-tier
         // RPM limits. On a paid BYOK provider (or paid Gemini tier) they'd be dead latency,
@@ -449,9 +454,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
 
         logger.error({ msg: "AI Analysis execution failed", error: error.message, stack: error.stack });
 
-        const failureReason = error.message.includes("429") || error.message.includes("Quota exceeded")
-            ? "AI Rate Limit Exceeded. Please wait a few minutes and try again."
-            : `Analysis Error: ${error.message}`;
+        const failureReason = sanitizeError(error, { providerHint: providerConfig?.provider }).message;
 
         // A daily/provider quota failure is recoverable when the user explicitly approved
         // an ordered fallback chain. Reuse the durable checkpoint and hand the same analysis
@@ -611,7 +614,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                         ...(analysisMeta || {}),
                         ...(resumable ? { checkpoint, resumable: true } : {}),
                         isPartial: true,
-                        failureReason: error.message,
+                        failureReason,
                         diagramSummary,
                         userFriendlyError
                     }
@@ -651,7 +654,7 @@ export const performAnalysis = async (userId, text, projectId = null, parentId =
                         checkpoint, // keep the latest checkpoint for resume
                         resumable,
                         failedStage: Object.keys(checkpoint).slice(-1)[0] || 'product_owner',
-                        failureReason: error.message,
+                        failureReason,
                         userFriendlyError: failureReason
                     }
                 }

--- a/backend/src/services/chatService.js
+++ b/backend/src/services/chatService.js
@@ -14,7 +14,11 @@ import logger from '../config/logger.js';
 async function resolveChatProvider(userId, currentAnalysis) {
     if (process.env.MOCK_AI === 'true') return {};
     const settings = currentAnalysis?.metadata?.promptSettings || {};
-    return resolveProviderKey(userId, settings.modelProvider, settings.modelName);
+    const resolved = await resolveProviderKey(userId, settings.modelProvider, settings.modelName);
+    // userId/allowModelFallback/fallbackModels were previously dropped here, which silently
+    // broke quota attribution (recordUsage/recordExhausted no-op on a falsy userId) and made
+    // fallback impossible for chat calls (selectNextFallbackModel requires userId).
+    return { ...resolved, userId, allowModelFallback: settings.allowModelFallback === true, fallbackModels: settings.fallbackModels };
 }
 
 // Same heuristic-keyword-branching philosophy already used in analysisService.js's

--- a/backend/src/services/providers/modelFallbackService.js
+++ b/backend/src/services/providers/modelFallbackService.js
@@ -84,6 +84,7 @@ export const selectNextFallbackModel = async (userId, settings = {}, attempted =
             return {
                 provider: resolved.provider,
                 modelName: resolved.modelName,
+                apiKey: resolved.apiKey,
                 inputTokenLimit: resolved.inputTokenLimit,
                 outputTokenLimit: resolved.outputTokenLimit
             };

--- a/backend/src/utils/errorSanitizer.js
+++ b/backend/src/utils/errorSanitizer.js
@@ -1,0 +1,99 @@
+import { ErrorCodes } from './errorCodes.js';
+
+/**
+ * Turns any error that might reach an HTTP response, SSE frame, or persisted
+ * `Analysis.metadata` field into a message safe to show a user — informative
+ * (names the provider when known) but never carrying raw SDK text, stack traces,
+ * or structured provider error payloads (which can include doc links, internal
+ * quota descriptors, or fragments of the request).
+ *
+ * Callers are still expected to log the raw `error` themselves; this function
+ * only decides what crosses the trust boundary into user-visible text.
+ *
+ * @param {Error} error
+ * @param {{ providerHint?: string }} [context] - human-readable provider name
+ *   (e.g. "Gemini") to use in the message when the caller has one in scope.
+ * @returns {{ message: string, code: string, statusCode: number, retryable: boolean }}
+ */
+export function sanitizeError(error, context = {}) {
+    const providerHint = context.providerHint || 'The AI provider';
+
+    if (!error) {
+        return { message: 'An unexpected error occurred.', code: ErrorCodes.INTERNAL_ERROR, statusCode: 500, retryable: false };
+    }
+
+    // A daily/billing quota failure already carries a deliberately-crafted, safe
+    // message (see quotaErrors.js) — never re-derive it.
+    if (error.quotaExhausted === true) {
+        return { message: error.message, code: ErrorCodes.AI_QUOTA_EXCEEDED, statusCode: 429, retryable: false };
+    }
+
+    // Anything our own code threw with a statusCode < 500 is a deliberate,
+    // client-actionable message (missing key, bad input, not found) — never raw
+    // provider text at this point in the codebase.
+    if (typeof error.statusCode === 'number' && error.statusCode < 500 && error.statusCode >= 400) {
+        return {
+            message: error.message,
+            code: error.code || (error.statusCode === 401 ? ErrorCodes.UNAUTHORIZED
+                : error.statusCode === 403 ? ErrorCodes.FORBIDDEN
+                    : error.statusCode === 404 ? ErrorCodes.PROJECT_NOT_FOUND
+                        : ErrorCodes.VALIDATION_FAILED),
+            statusCode: error.statusCode,
+            retryable: false
+        };
+    }
+
+    const haystack = `${error.message || ''} ${error.code || ''} ${error.error?.code || ''} ${error.error?.type || ''}`;
+
+    if (error.message === 'AI Request Timeout') {
+        return {
+            message: `The request to ${providerHint} took too long and was cancelled. Please try again.`,
+            code: ErrorCodes.GATEWAY_TIMEOUT,
+            statusCode: 504,
+            retryable: true
+        };
+    }
+
+    if (/fetch failed|ECONNREFUSED|ENOTFOUND|network/i.test(haystack)) {
+        return {
+            message: `Could not reach ${providerHint}. Please check your connection and try again.`,
+            code: ErrorCodes.SERVICE_UNAVAILABLE,
+            statusCode: 503,
+            retryable: true
+        };
+    }
+
+    if (/\b503\b|service unavailable|overloaded|\bUNAVAILABLE\b/i.test(haystack)) {
+        return {
+            message: `${providerHint} is currently experiencing high demand. Please try again in a moment.`,
+            code: ErrorCodes.SERVICE_UNAVAILABLE,
+            statusCode: 503,
+            retryable: true
+        };
+    }
+
+    if (/\b401\b|\b403\b|invalid[_ ]api[_ ]key|authentication_error|unauthorized/i.test(haystack)) {
+        return {
+            message: `The ${providerHint} API key on this account was rejected. Update it in Settings.`,
+            code: ErrorCodes.UNAUTHORIZED,
+            statusCode: 401,
+            retryable: false
+        };
+    }
+
+    if (/\b429\b|quota|rate limit/i.test(haystack)) {
+        return {
+            message: `${providerHint} is rate-limiting requests right now. Please wait a moment and try again.`,
+            code: ErrorCodes.RATE_LIMIT_EXCEEDED,
+            statusCode: 429,
+            retryable: true
+        };
+    }
+
+    return {
+        message: 'An unexpected error occurred while generating this content. Our team has been notified.',
+        code: ErrorCodes.AI_PROCESSING_ERROR,
+        statusCode: 500,
+        retryable: false
+    };
+}

--- a/backend/tests/unit/base_agent_fallback.test.js
+++ b/backend/tests/unit/base_agent_fallback.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+
+const mockSelectNextFallbackModel = jest.fn();
+
+jest.unstable_mockModule('../../src/services/providers/modelFallbackService.js', () => ({
+    selectNextFallbackModel: mockSelectNextFallbackModel
+}));
+
+const { BaseAgent } = await import('../../src/agents/BaseAgent.js');
+
+const SERVER_ERROR = new Error('[503 Service Unavailable] The model is overloaded. Please try again later.');
+const AUTH_ERROR = new Error('[401 Unauthorized] Invalid API key');
+
+function agentWithFailure(error, classification, { failures = Infinity, providerConfig = {} } = {}) {
+    const agent = new BaseAgent('Test Agent', {
+        provider: 'gemini',
+        modelName: 'gemini-3.5-flash',
+        apiKey: 'gemini-key',
+        userId: 'u1',
+        allowModelFallback: true,
+        fallbackModels: [{ modelProvider: 'CLAUDE', modelName: 'claude-backup' }],
+        ...providerConfig
+    });
+    const state = { calls: 0, adapters: [] };
+
+    const makeAdapter = (label) => ({
+        generateContent: async () => {
+            state.calls++;
+            state.adapters.push(label);
+            if (state.calls > failures) return 'recovered';
+            throw error;
+        },
+        classifyError: () => classification
+    });
+
+    // getAdapter is overridden rather than the private _adapter field, matching how
+    // BaseAgent itself resolves the adapter fresh each retry loop iteration.
+    agent.getAdapter = () => makeAdapter(`${agent.provider}:${agent.modelName}`);
+
+    return { agent, state };
+}
+
+describe('BaseAgent.callLLM — provider fallback', () => {
+    const originalMockAi = process.env.MOCK_AI;
+
+    afterEach(() => {
+        process.env.MOCK_AI = originalMockAi;
+        mockSelectNextFallbackModel.mockReset();
+    });
+
+    it('falls back to the next approved provider on the first overload, without exhausting same-provider retries', async () => {
+        process.env.MOCK_AI = 'false';
+        mockSelectNextFallbackModel.mockResolvedValueOnce({
+            provider: 'CLAUDE', modelName: 'claude-backup', apiKey: 'claude-key',
+            inputTokenLimit: 2000, outputTokenLimit: 1000
+        });
+        const { agent, state } = agentWithFailure(
+            SERVER_ERROR,
+            { isRateLimit: false, isServerError: true, isAuthError: false },
+            { failures: 1 } // the (single) call against the fallback provider succeeds
+        );
+
+        const result = await agent.callLLM('prompt', 0.2, false, null, 3);
+
+        expect(result).toBe('recovered');
+        // One failed call against Gemini, then straight to the fallback — not three
+        // same-provider attempts first.
+        expect(state.calls).toBe(2);
+        expect(state.adapters).toEqual(['GEMINI:gemini-3.5-flash', 'CLAUDE:claude-backup']);
+        expect(agent.provider).toBe('CLAUDE');
+        expect(agent.modelName).toBe('claude-backup');
+    });
+
+    it('preserves today\'s same-provider retry behavior when no fallback is configured', async () => {
+        process.env.MOCK_AI = 'false';
+        const { agent, state } = agentWithFailure(
+            SERVER_ERROR,
+            { isRateLimit: false, isServerError: true, isAuthError: false },
+            { failures: 1, providerConfig: { allowModelFallback: false } }
+        );
+
+        // Small initialDelay so the preserved same-provider backoff doesn't slow the test.
+        const result = await agent.callLLM('prompt', 0.2, false, null, 3, 50);
+
+        expect(result).toBe('recovered');
+        expect(state.calls).toBe(2);
+        expect(mockSelectNextFallbackModel).not.toHaveBeenCalled();
+    });
+
+    it('throws the final sanitizable error when fallback is configured but no candidate is available', async () => {
+        process.env.MOCK_AI = 'false';
+        mockSelectNextFallbackModel.mockResolvedValue(null);
+        const { agent, state } = agentWithFailure(
+            SERVER_ERROR,
+            { isRateLimit: false, isServerError: true, isAuthError: false }
+        );
+
+        await expect(agent.callLLM('prompt', 0.2, false, null, 3, 50)).rejects.toThrow(/failed to generate content/);
+        // No fallback candidate → falls through to the same-provider last-resort retry
+        // budget (3 attempts) before finally throwing.
+        expect(state.calls).toBe(4);
+    });
+
+    it('attempts a fallback for an auth error without any same-provider retry first', async () => {
+        process.env.MOCK_AI = 'false';
+        mockSelectNextFallbackModel.mockResolvedValueOnce({
+            provider: 'CLAUDE', modelName: 'claude-backup', apiKey: 'claude-key',
+            inputTokenLimit: 2000, outputTokenLimit: 1000
+        });
+        const { agent, state } = agentWithFailure(
+            AUTH_ERROR,
+            { isRateLimit: false, isServerError: false, isAuthError: true },
+            { failures: 1 }
+        );
+
+        const result = await agent.callLLM('prompt', 0.2, false, null, 3);
+
+        expect(result).toBe('recovered');
+        // Exactly one failed call against the rejected key, then the fallback succeeds —
+        // no wasted same-provider retries against a key that will never start working.
+        expect(state.calls).toBe(2);
+        expect(agent.provider).toBe('CLAUDE');
+    });
+
+    it('keeps using the fallback provider for the agent\'s next, separate call', async () => {
+        process.env.MOCK_AI = 'false';
+        mockSelectNextFallbackModel.mockResolvedValueOnce({
+            provider: 'CLAUDE', modelName: 'claude-backup', apiKey: 'claude-key',
+            inputTokenLimit: 2000, outputTokenLimit: 1000
+        });
+        const { agent } = agentWithFailure(
+            SERVER_ERROR,
+            { isRateLimit: false, isServerError: true, isAuthError: false },
+            { failures: 1 }
+        );
+
+        await agent.callLLM('prompt', 0.2, false, null, 3);
+        expect(agent.provider).toBe('CLAUDE');
+
+        // A second, independent call should go straight to Claude — no rediscovery of
+        // Gemini's failure — since the agent instance remembers the switch.
+        agent.getAdapter = () => ({
+            generateContent: async () => 'second-call-result',
+            classifyError: () => ({ isRateLimit: false, isServerError: false, isAuthError: false })
+        });
+        const secondResult = await agent.callLLM('prompt2', 0.2, false, null, 3);
+        expect(secondResult).toBe('second-call-result');
+        expect(mockSelectNextFallbackModel).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/tests/unit/error_middleware.test.js
+++ b/backend/tests/unit/error_middleware.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { errorHandler } from '../../src/middleware/errorMiddleware.js';
+
+function mockRes() {
+    const res = { statusCode: null, body: null, headers: {} };
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    res.set = jest.fn((key, value) => { res.headers[key] = value; return res; });
+    return res;
+}
+
+const req = { id: 'req-1' };
+const next = () => {};
+
+describe('errorHandler', () => {
+    it('sanitizes a raw provider-shaped error before it reaches the response body', () => {
+        const err = new Error('[GoogleGenerativeAI Error]: [503 Service Unavailable] The model is overloaded.');
+        const res = mockRes();
+
+        errorHandler(err, req, res, next);
+
+        expect(res.statusCode).toBe(503);
+        expect(res.body.message).not.toContain('GoogleGenerativeAI');
+        expect(res.body.success).toBe(false);
+    });
+
+    it('passes a deliberately-thrown client error (statusCode < 500) through verbatim', () => {
+        const err = Object.assign(new Error('No GEMINI API key configured. Add your own key in Settings.'), { statusCode: 400 });
+        const res = mockRes();
+
+        errorHandler(err, req, res, next);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toBe(err.message);
+    });
+
+    it('never includes a stack trace outside development', () => {
+        const originalEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        const err = new Error('boom');
+        const res = mockRes();
+
+        errorHandler(err, req, res, next);
+
+        expect(res.body.details).toBeUndefined();
+        process.env.NODE_ENV = originalEnv;
+    });
+});

--- a/backend/tests/unit/error_sanitizer.test.js
+++ b/backend/tests/unit/error_sanitizer.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from '@jest/globals';
+import { sanitizeError } from '../../src/utils/errorSanitizer.js';
+import { ErrorCodes } from '../../src/utils/errorCodes.js';
+import { buildExhaustedQuotaError } from '../../src/utils/quotaErrors.js';
+
+// Raw shapes actually observed from provider SDKs / our own code — see errorSanitizer.js
+// and the leak points it replaces (analysisService.js, analysisController.js).
+const GEMINI_OVERLOAD = new Error(
+    '[GoogleGenerativeAI Error]: [503 Service Unavailable] The model is overloaded. Please try again later.'
+);
+const GEMINI_QUOTA_JSON = new Error(
+    '[GoogleGenerativeAI Error]: [429 Too Many Requests] Quota exceeded for metric: generate_content_free_tier_requests, ' +
+    'limit: 20. [{"@type":"type.googleapis.com/google.rpc.QuotaFailure","violations":[{"quotaId":"GenerateRequestsPerDayPerProjectPerModel-FreeTier"}]}]'
+);
+// Provider SDK errors carry `.status` (see OpenAIAdapter.js/ClaudeAdapter.js), never the
+// `.statusCode` our own deliberately-thrown errors use — sanitizeError's pass-through rule
+// keys on `.statusCode` specifically so a raw SDK error is never mistaken for a safe one.
+const OPENAI_INSUFFICIENT_QUOTA = Object.assign(
+    new Error('You exceeded your current quota, please check your plan and billing details.'),
+    { code: 'insufficient_quota', status: 429 }
+);
+const CLAUDE_AUTH = Object.assign(
+    new Error('{"type":"authentication_error","message":"invalid x-api-key sk-ant-api03-xxxx"}'),
+    { status: 401 }
+);
+const PLAIN_ERROR = new Error('boom');
+const APP_400 = Object.assign(new Error('No GEMINI API key configured. Add your own key in Settings.'), { statusCode: 400 });
+const QUOTA_EXHAUSTED = buildExhaustedQuotaError(new Error('limit: 20, PerDay'), 'gemini-3.5-flash');
+
+const FORBIDDEN_SUBSTRINGS = ['@type', 'google.rpc', 'sk-ant-api03', 'GenerateRequestsPerDay', 'x-api-key'];
+
+describe('sanitizeError', () => {
+    it.each([
+        ['Gemini overload/503', GEMINI_OVERLOAD, { providerHint: 'Gemini' }, 503],
+        ['Gemini quota JSON blob', GEMINI_QUOTA_JSON, { providerHint: 'Gemini' }, 429],
+        ['OpenAI insufficient_quota', OPENAI_INSUFFICIENT_QUOTA, { providerHint: 'OpenAI' }, 429],
+        ['Claude auth error', CLAUDE_AUTH, { providerHint: 'Claude' }, 401],
+        ['plain unclassified error', PLAIN_ERROR, {}, 500]
+    ])('never leaks raw SDK/internal text for: %s', (_label, error, context, expectedStatus) => {
+        const result = sanitizeError(error, context);
+
+        for (const substring of FORBIDDEN_SUBSTRINGS) {
+            expect(result.message).not.toContain(substring);
+        }
+        expect(result.message).not.toBe(error.message);
+        expect(result.statusCode).toBe(expectedStatus);
+        expect(Object.values(ErrorCodes)).toContain(result.code);
+    });
+
+    it('names the provider in the message when a hint is given', () => {
+        const result = sanitizeError(GEMINI_OVERLOAD, { providerHint: 'Gemini' });
+        expect(result.message).toContain('Gemini');
+    });
+
+    it('passes an already-safe quota-exhausted message through unchanged', () => {
+        const result = sanitizeError(QUOTA_EXHAUSTED);
+        expect(result.message).toBe(QUOTA_EXHAUSTED.message);
+        expect(result.code).toBe(ErrorCodes.AI_QUOTA_EXCEEDED);
+        expect(result.statusCode).toBe(429);
+    });
+
+    it('passes our own deliberately-thrown client-actionable (<500) messages through unchanged', () => {
+        const result = sanitizeError(APP_400);
+        expect(result.message).toBe(APP_400.message);
+        expect(result.statusCode).toBe(400);
+    });
+
+    it('never leaks a stack trace', () => {
+        const result = sanitizeError(GEMINI_OVERLOAD);
+        expect(result.message).not.toContain('at ');
+        expect(result.message).not.toContain('.js:');
+    });
+});

--- a/backend/tests/unit/model_fallback.test.js
+++ b/backend/tests/unit/model_fallback.test.js
@@ -33,6 +33,7 @@ beforeEach(() => {
     mockResolveProviderKey.mockImplementation(async (_userId, provider, modelName) => ({
         provider,
         modelName,
+        apiKey: `decrypted-key-${provider}`,
         inputTokenLimit: 1000,
         outputTokenLimit: 500
     }));
@@ -67,9 +68,22 @@ describe('selectNextFallbackModel', () => {
         await expect(selectNextFallbackModel('u1', settings, [])).resolves.toEqual({
             provider: 'GEMINI',
             modelName: 'gemini-backup',
+            apiKey: 'decrypted-key-GEMINI',
             inputTokenLimit: 1000,
             outputTokenLimit: 500
         });
+    });
+
+    it('includes the decrypted apiKey so BaseAgent can use the fallback without a second lookup', async () => {
+        // Regression guard: the return object previously omitted apiKey even though
+        // resolveProviderKey's result carries it, which left a caller with no usable key
+        // for the fallback provider.
+        await expect(selectNextFallbackModel('u1', {
+            modelProvider: 'GEMINI',
+            modelName: 'gemini-primary',
+            allowModelFallback: true,
+            fallbackModels: [{ modelProvider: 'OPENAI', modelName: 'gpt-backup' }]
+        })).resolves.toHaveProperty('apiKey', 'decrypted-key-OPENAI');
     });
 
     it('skips exhausted, unavailable, and already attempted models', async () => {

--- a/frontend/app/(shell)/analysis/[id]/page.tsx
+++ b/frontend/app/(shell)/analysis/[id]/page.tsx
@@ -356,7 +356,7 @@ function AnalysisDetailContent() {
 
         } catch (e) {
             console.error("Failed to proceed to analysis", e);
-            toast.error("Failed to proceed to analysis");
+            toast.error(e instanceof Error ? e.message : "Failed to proceed to analysis");
             setIsProceeding(false);
         }
     }
@@ -514,8 +514,8 @@ function AnalysisDetailContent() {
             <div className="min-h-screen flex flex-col bg-background">
                 <div className="border-b border-foreground/10 px-6 py-4 flex items-center justify-between sticky top-0 bg-background z-20">
                     <div className="flex items-center gap-4 min-w-0">
-                        <Button variant="ghost" size="icon" onClick={() => router.push('/analysis')} aria-label="Back to analyses">
-                            <ArrowLeft className="h-4 w-4" />
+                        <Button variant="ghost" size="sm" className="shrink-0 gap-1.5" onClick={() => router.push('/analysis')}>
+                            <ArrowLeft className="h-4 w-4" /> Back
                         </Button>
                         <h1 className="text-xl font-display truncate">
                             {draftData?.details?.projectName?.content || analysis?.title?.replace(" (Draft)", "") || "New Analysis"}
@@ -546,7 +546,7 @@ function AnalysisDetailContent() {
     }
 
     if (isTerminal && analysis) {
-        const projectLabel = draftData?.details?.projectName?.content || analysis.projectTitle || analysis.title || "Analysis Result"
+        const projectLabel = draftData?.details?.projectName?.content || analysis.projectTitle || analysis.title || "Analysis"
         return (
             <div className="h-screen flex flex-col bg-background">
                 {/* One surface at a time, each full-width: the conversation (refinement)
@@ -554,8 +554,8 @@ function AnalysisDetailContent() {
                     side-by-side split. */}
                 <div className="border-b border-foreground/10 px-4 py-2.5 flex items-center justify-between gap-4 shrink-0">
                     <div className="flex items-center gap-2 min-w-0">
-                        <Button variant="ghost" size="icon" onClick={() => router.push('/analysis')} aria-label="Back to analyses">
-                            <ArrowLeft className="h-4 w-4" />
+                        <Button variant="ghost" size="sm" className="shrink-0 gap-1.5" onClick={() => router.push('/analysis')}>
+                            <ArrowLeft className="h-4 w-4" /> Back
                         </Button>
                         <h1 className="text-sm font-medium truncate">{projectLabel}</h1>
                     </div>
@@ -625,7 +625,9 @@ function AnalysisDetailContent() {
         <div className="min-h-screen flex flex-col bg-background">
             <div className="border-b border-foreground/10 px-6 py-4 flex items-center justify-between sticky top-0 bg-background z-20">
                 <div className="flex items-center gap-4">
-                    <Button variant="ghost" size="icon" onClick={() => router.push('/analysis')}><ArrowLeft className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="sm" className="gap-1.5" onClick={() => router.push('/analysis')}>
+                        <ArrowLeft className="h-4 w-4" /> Back
+                    </Button>
                     <div>
                         <h1 className="text-xl font-display">{analysis?.title?.replace(" (Draft)", "") || "New Analysis"}</h1>
                     </div>

--- a/frontend/app/(shell)/analysis/new/page.tsx
+++ b/frontend/app/(shell)/analysis/new/page.tsx
@@ -20,6 +20,7 @@ import { listFormatSpecs } from "@/lib/formats"
 import { runValidation } from "@/lib/analysis-api"
 import { requestNotificationPermission } from "@/lib/notifications"
 import { useModelQuota, describeQuota, quotaKey } from "@/lib/model-quota"
+import { extractErrorMessage } from "@/lib/api-response"
 
 // No model id is hardcoded here — the picker fills modelName in from the models the
 // user's own provider keys expose (see buildModelOptions + NEXT_PUBLIC_GEMINI_MODELS).
@@ -227,7 +228,7 @@ function NewAnalysisContent() {
 
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({}))
-                throw new Error(errorData.message || errorData.error || "Failed to initialize analysis.")
+                throw new Error(extractErrorMessage(errorData, "Failed to initialize analysis."))
             }
 
             const json = await response.json()
@@ -566,7 +567,7 @@ function NewAnalysisContent() {
                 {hasNoKeys && (
                     <Link
                         href="/settings"
-                        className="mt-3 flex items-center justify-center gap-2 rounded-xl border border-amber-500/30 bg-amber-500/5 px-3 py-2.5 text-xs text-amber-700 dark:text-amber-400 hover:bg-amber-500/10 transition-colors"
+                        className="mt-3 flex items-center justify-center gap-2 rounded-xl border border-amber-500/30 bg-amber-500/5 px-3 py-2.5 text-xs text-amber-700 hover:bg-amber-500/10 transition-colors"
                     >
                         <KeyRound className="h-3.5 w-3.5 shrink-0" />
                         You need your own API key to generate. Add a Gemini, OpenAI, Claude, or Grok key in Settings.

--- a/frontend/app/(shell)/analysis/page.tsx
+++ b/frontend/app/(shell)/analysis/page.tsx
@@ -4,11 +4,14 @@ import { useEffect, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/lib/auth-context"
 import useSWR from "swr";
+import { toast } from "sonner"
+import { AlertTriangle } from "lucide-react"
 import { createAuthFetcher, swrOptions } from "@/lib/swr-utils";
 import { useAuthFetch, useRevalidateOnRestore } from "@/lib/hooks";
 
 import { AnalysisHistory } from "@/components/analysis-history"
 import { Skeleton } from "@/components/ui/skeleton"
+import { EmptyState } from "@/components/ui/empty-state"
 
 type AnalysisHistoryItem = {
     id: string
@@ -49,6 +52,10 @@ export default function AnalysisPage() {
         }
     }, [user, token, authLoading, router])
 
+    useEffect(() => {
+        if (error) toast.error("Couldn't load your analyses. Please try again.");
+    }, [error]);
+
     if (authLoading || isLoading) {
         return (
             <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-10 py-8 sm:py-12">
@@ -81,7 +88,17 @@ export default function AnalysisPage() {
                 </p>
             </div>
 
-            <AnalysisHistory items={history} />
+            {error ? (
+                <EmptyState
+                    variant="error"
+                    icon={AlertTriangle}
+                    heading="Couldn't load your analyses"
+                    description="Something went wrong while fetching your analysis history."
+                    cta={{ label: "Retry", onClick: () => mutate() }}
+                />
+            ) : (
+                <AnalysisHistory items={history} />
+            )}
         </div>
     )
 }

--- a/frontend/app/(shell)/projects/[id]/page.tsx
+++ b/frontend/app/(shell)/projects/[id]/page.tsx
@@ -8,9 +8,10 @@ import { cleanInputText } from "@/lib/utils";
 
 import Link from "next/link";
 import { toast } from "sonner";
-import { format } from "date-fns";
+import { formatAbsolute } from "@/lib/format-date";
 import { ArrowLeft, Edit2, Trash2, FileText, Calendar, Plus } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
 import { useRouter, useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -44,8 +45,8 @@ export default function ProjectDetailPage() {
                 setProject(data);
                 setEditName(data.name);
                 setEditDesc(data.description || "");
-            } catch {
-                toast.error("Failed to load project");
+            } catch (e) {
+                toast.error(e instanceof Error ? e.message : "Failed to load project");
                 router.push("/projects");
             } finally {
                 setIsLoading(false);
@@ -67,8 +68,8 @@ export default function ProjectDetailPage() {
             setProject(updated);
             setIsEditing(false);
             toast.success("Project updated");
-        } catch {
-            toast.error("Failed to update project");
+        } catch (e) {
+            toast.error(e instanceof Error ? e.message : "Failed to update project");
         }
     };
 
@@ -77,8 +78,8 @@ export default function ProjectDetailPage() {
             await deleteProject(token!, project!.id);
             toast.success("Project deleted");
             router.push("/projects");
-        } catch {
-            toast.error("Failed to delete project");
+        } catch (e) {
+            toast.error(e instanceof Error ? e.message : "Failed to delete project");
         }
     };
 
@@ -141,7 +142,7 @@ export default function ProjectDetailPage() {
                         <p className="text-muted-foreground">{project?.description}</p>
                         <div className="flex gap-4 mt-4 text-sm text-muted-foreground">
                             <span className="flex items-center gap-1 font-mono text-xs">
-                                <Calendar size={13} /> Created {format(new Date(project!.createdAt), 'PPP')}
+                                <Calendar size={13} /> Created {formatAbsolute(project!.createdAt)}
                             </span>
                         </div>
                     </div>
@@ -200,14 +201,19 @@ export default function ProjectDetailPage() {
                                         {cleanInputText(analysis.inputText || "")}
                                     </p>
                                     <div className="flex justify-between mt-2 text-xs text-muted-foreground font-mono">
-                                        <span>{format(new Date(analysis.createdAt), 'MMM d, h:mm a')}</span>
+                                        <span>{formatAbsolute(analysis.createdAt)}</span>
                                     </div>
                                 </div>
                             </Link>
                         ))}
                     </div>
                 ) : (
-                    <p className="text-muted-foreground italic text-sm">No analyses in this project yet.</p>
+                    <EmptyState
+                        icon={FileText}
+                        heading="No analyses yet"
+                        description="Start a new analysis to turn this project's requirements into a spec."
+                        cta={{ label: "New analysis", onClick: () => router.push(`/analysis/new?projectId=${project?.id}`) }}
+                    />
                 )}
             </div>
         </div>

--- a/frontend/app/(shell)/projects/page.tsx
+++ b/frontend/app/(shell)/projects/page.tsx
@@ -11,7 +11,7 @@ import { useAuthFetch } from "@/lib/hooks";
 
 import Link from "next/link";
 import { toast } from "sonner";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelative } from "@/lib/format-date";
 import { Plus, Folder, MessageSquare, Search, Clock, ArrowUpRight, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -67,8 +67,8 @@ export default function ProjectsPage() {
             try {
                 const data = await fetchProjects(token!);
                 setProjects(data);
-            } catch {
-                toast.error("Failed to load projects");
+            } catch (e) {
+                toast.error(e instanceof Error ? e.message : "Failed to load projects");
             } finally {
                 Promise.resolve().then(() => setIsLoading(false));
             }
@@ -90,8 +90,8 @@ export default function ProjectsPage() {
             setNewProjectName("");
             setIsCreating(false);
             toast.success("Project created");
-        } catch {
-            toast.error("Failed to create project");
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : "Failed to create project");
         }
     };
 
@@ -111,7 +111,7 @@ export default function ProjectsPage() {
                     <div>
                         <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight">Projects</h1>
                         <p className="mt-1 text-sm text-muted-foreground">
-                            Workspaces for the systems you&apos;re specifying.
+                            Projects for the systems you&apos;re specifying.
                         </p>
                     </div>
                     <div className="flex items-center gap-2">
@@ -182,7 +182,7 @@ export default function ProjectsPage() {
                                         {item.title || item.inputPreview || "Untitled analysis"}
                                     </p>
                                     <p className="mt-1.5 text-xs text-muted-foreground">
-                                        {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+                                        {formatRelative(item.createdAt)}
                                     </p>
                                 </Link>
                             ))}
@@ -250,7 +250,7 @@ export default function ProjectsPage() {
                                             {project.description || "No description yet."}
                                         </p>
                                         <div className="mt-5 flex items-center justify-between border-t border-border/70 pt-3 text-xs text-muted-foreground">
-                                            <span>Updated {formatDistanceToNow(new Date(project.updatedAt), { addSuffix: true })}</span>
+                                            <span>Updated {formatRelative(project.updatedAt)}</span>
                                             <ArrowUpRight className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />
                                         </div>
                                     </div>

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -63,7 +63,7 @@ export default function LoginPage() {
             <div className="relative z-10 w-full max-w-md">
                 <Link href="/" className="flex items-center justify-center gap-2 mb-10">
                     <span className="text-2xl font-display">SRA</span>
-                    <span className="text-xs text-muted-foreground font-mono mt-1">IEEE-830</span>
+                    <span className="text-xs text-muted-foreground font-mono mt-1">MULTI-FORMAT</span>
                 </Link>
 
                 <div className="border border-foreground/10 p-8 lg:p-10">

--- a/frontend/app/auth/signup/page.tsx
+++ b/frontend/app/auth/signup/page.tsx
@@ -64,7 +64,7 @@ export default function SignupPage() {
             <div className="relative z-10 w-full max-w-md">
                 <Link href="/" className="flex items-center justify-center gap-2 mb-10">
                     <span className="text-2xl font-display">SRA</span>
-                    <span className="text-xs text-muted-foreground font-mono mt-1">IEEE-830</span>
+                    <span className="text-xs text-muted-foreground font-mono mt-1">MULTI-FORMAT</span>
                 </Link>
 
                 <div className="border border-foreground/10 p-8 lg:p-10">

--- a/frontend/components/DFDViewer.tsx
+++ b/frontend/components/DFDViewer.tsx
@@ -34,6 +34,7 @@ type DFDNodeType = Node<DFDNodeData>;
 
 // -----------------------------------------------------------------------------
 import { motion } from 'framer-motion';
+import { DIAGRAM_EDGE_THEME } from '@/lib/diagram-theme';
 
 // ... (keep nodeTypes as is)
 
@@ -188,13 +189,13 @@ const DiagramCanvas = ({ title, data, isExport = false }: DiagramCanvasProps) =>
             animated: true,
             markerEnd: {
                 type: MarkerType.ArrowClosed,
-                color: '#334155',
+                color: DIAGRAM_EDGE_THEME.arrowColor,
                 width: 20,
                 height: 20
             },
-            style: { stroke: '#64748b', strokeWidth: 2.5 },
-            labelStyle: { fill: '#0f172a', fontWeight: 800, fontSize: 10 },
-            labelBgStyle: { fill: '#f8fafc', fillOpacity: 0.9, rx: 4 }
+            style: { stroke: DIAGRAM_EDGE_THEME.edgeStroke, strokeWidth: 2.5 },
+            labelStyle: { fill: DIAGRAM_EDGE_THEME.labelText, fontWeight: 800, fontSize: 10 },
+            labelBgStyle: { fill: DIAGRAM_EDGE_THEME.labelBackground, fillOpacity: 0.9, rx: 4 }
         }));
 
         setNodes(initialNodes);
@@ -212,7 +213,7 @@ const DiagramCanvas = ({ title, data, isExport = false }: DiagramCanvasProps) =>
 
         try {
             const dataUrl = await toPng(containerRef.current, {
-                backgroundColor: '#ffffff',
+                backgroundColor: DIAGRAM_EDGE_THEME.canvasExportBackground,
                 quality: 1,
                 pixelRatio: 2, // Retína quality
             });
@@ -267,7 +268,7 @@ const DiagramCanvas = ({ title, data, isExport = false }: DiagramCanvasProps) =>
                     maxZoom={2}
                     nodesConnectable={false}
                 >
-                    <Background color="#aaa" gap={16} />
+                    <Background color={DIAGRAM_EDGE_THEME.gridDot} gap={16} />
                     {!isExport && <Controls />}
                 </ReactFlow>
             </div>

--- a/frontend/components/analysis-history.tsx
+++ b/frontend/components/analysis-history.tsx
@@ -4,9 +4,10 @@ import { useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar, ArrowRight, FileText } from "lucide-react"
-import { formatDistanceToNow } from "date-fns"
+import { formatRelative } from "@/lib/format-date"
 import { cleanInputText } from "@/lib/utils"
 import { toast } from "sonner"
+import { EmptyState } from "@/components/ui/empty-state"
 
 interface AnalysisHistoryItem {
     id: string
@@ -28,10 +29,10 @@ function StatusPill({ status, resultQuality }: { status?: string; resultQuality?
         return <Badge className="h-6 px-2 text-xs shrink-0 border-transparent bg-destructive/10 text-destructive">Failed · resume</Badge>
     }
     if (s === "PENDING" || s === "IN_PROGRESS" || s === "QUEUED") {
-        return <Badge className="h-6 px-2 text-xs shrink-0 border-transparent bg-amber-500/10 text-amber-600 dark:text-amber-400">In progress</Badge>
+        return <Badge className="h-6 px-2 text-xs shrink-0 border-transparent bg-amber-500/10 text-amber-600">In progress</Badge>
     }
     if ((resultQuality || "").toUpperCase() === "PARTIAL") {
-        return <Badge className="h-6 px-2 text-xs shrink-0 border-transparent bg-amber-500/10 text-amber-600 dark:text-amber-400">Partial</Badge>
+        return <Badge className="h-6 px-2 text-xs shrink-0 border-transparent bg-amber-500/10 text-amber-600">Partial</Badge>
     }
     return null
 }
@@ -45,15 +46,11 @@ export function AnalysisHistory({ items }: AnalysisHistoryProps) {
 
     if (items.length === 0) {
         return (
-            <div className="text-center py-12">
-                <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted mb-4">
-                    <FileText className="h-6 w-6 text-muted-foreground" />
-                </div>
-                <h3 className="text-lg font-medium">No analyses yet</h3>
-                <p className="text-muted-foreground mt-2 max-w-sm mx-auto">
-                    Start by entering your project requirements in the analyzer on the home page.
-                </p>
-            </div>
+            <EmptyState
+                icon={FileText}
+                heading="No analyses yet"
+                description="Start by entering your project requirements in the analyzer on the home page."
+            />
         )
     }
 
@@ -84,14 +81,14 @@ export function AnalysisHistory({ items }: AnalysisHistoryProps) {
                                         v{item.version || 1}
                                     </Badge>
                                     <CardTitle className="text-base font-semibold group-hover:text-primary transition-colors line-clamp-1">
-                                        {item.title || "Requirements Analysis"}
+                                        {item.title || "Analysis"}
                                     </CardTitle>
                                     <StatusPill status={item.status} resultQuality={item.resultQuality} />
                                 </div>
                             </div>
                             <div className="flex items-center gap-2 text-sm text-muted-foreground shrink-0">
                                 <Calendar className="h-3.5 w-3.5" />
-                                <span className="hidden xs:inline">{formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}</span>
+                                <span className="hidden xs:inline">{formatRelative(item.createdAt)}</span>
                             </div>
                         </CardHeader>
 
@@ -101,7 +98,7 @@ export function AnalysisHistory({ items }: AnalysisHistoryProps) {
                             </p>
 
                             <div className="flex items-center gap-1 text-xs text-primary font-medium mt-3 opacity-0 -translate-x-2 transition-all duration-300 group-hover:opacity-100 group-hover:translate-x-0">
-                                {(item.status || "").toUpperCase() === "FAILED" ? "Resume analysis" : "View Details"} <ArrowRight className="h-3 w-3" />
+                                {(item.status || "").toUpperCase() === "FAILED" ? "Resume analysis" : "View details"} <ArrowRight className="h-3 w-3" />
                             </div>
                         </CardContent>
                     </Card>

--- a/frontend/components/analysis/analysis-conversation.tsx
+++ b/frontend/components/analysis/analysis-conversation.tsx
@@ -10,6 +10,7 @@ import { cn, cleanInputText } from "@/lib/utils"
 import { toast } from "sonner"
 import { readSSEStream } from "@/lib/sse"
 import { MarkdownDisplay } from "@/components/markdown-display"
+import { getFormatSpec, resolveFormatId } from "@/lib/formats"
 import type { Analysis } from "@/types/analysis"
 
 interface ChatStreamEvent {
@@ -224,7 +225,7 @@ export function AnalysisConversation({ analysis, analysisId, onAnalysisUpdate, h
                     <Bubble role="assistant">
                         <div className="space-y-3">
                             <p>
-                                I&apos;ve drafted your IEEE-830 SRS
+                                I&apos;ve drafted your {getFormatSpec(resolveFormatId(analysis)).name} specification
                                 {analysis.metadata?.optimized ? " using recycled requirements from your knowledge base" : ""}.
                             </p>
                             <button
@@ -234,7 +235,7 @@ export function AnalysisConversation({ analysis, analysisId, onAnalysisUpdate, h
                             >
                                 <span className="font-display text-2xl text-foreground/25 leading-none group-hover:text-foreground/50 transition-colors">01</span>
                                 <div className="min-w-0 flex-1">
-                                    <p className="font-display text-lg truncate leading-tight">{analysis.projectTitle || analysis.title || "SRS Document"}</p>
+                                    <p className="font-display text-lg truncate leading-tight">{analysis.projectTitle || analysis.title || "Specification"}</p>
                                     <p className="text-[11px] text-muted-foreground font-mono uppercase tracking-wider mt-0.5">
                                         {sectionCount} feature{sectionCount === 1 ? "" : "s"} · v{analysis.version} · open document
                                     </p>

--- a/frontend/components/analysis/cli-traceability-panel.tsx
+++ b/frontend/components/analysis/cli-traceability-panel.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import { formatAbsolute } from "@/lib/format-date"
 
 /** One requirement group as `sra push` recorded it. */
 export interface CliTraceabilityGroup {
@@ -81,7 +82,7 @@ export function CliTraceabilityPanel({ traceability }: { traceability?: CliTrace
                 <CardDescription className="text-[10px]">
                     Reported by the SRA CLI
                     {traceability?.cliVersion ? ` v${traceability.cliVersion}` : ""}
-                    {traceability?.updatedAt ? ` · ${new Date(traceability.updatedAt).toLocaleString()}` : ""}
+                    {traceability?.updatedAt ? ` · ${formatAbsolute(traceability.updatedAt)}` : ""}
                     {" · links point at files in the developer's working tree, not a proof of correctness"}
                 </CardDescription>
             </CardHeader>

--- a/frontend/components/analysis/document-canvas.tsx
+++ b/frontend/components/analysis/document-canvas.tsx
@@ -70,7 +70,7 @@ export function DocumentCanvas({
             <div className="border-b border-foreground/10 px-4 py-3 flex items-center justify-between gap-3 shrink-0">
                 <div className="min-w-0 flex items-center gap-2">
                     <span className="font-display text-lg truncate">
-                        {analysis.projectTitle || analysis.title || "SRS Document"}
+                        {analysis.projectTitle || analysis.title || "Specification"}
                     </span>
                     <span className="shrink-0 px-2 py-0.5 border border-foreground/10 text-xs font-mono">
                         v{analysis.version}

--- a/frontend/components/analysis/tabs/knowledge-graph-tab.tsx
+++ b/frontend/components/analysis/tabs/knowledge-graph-tab.tsx
@@ -25,6 +25,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { useAuthFetch } from "@/lib/hooks"
 import { toast } from "sonner"
+import { DIAGRAM_EDGE_THEME } from "@/lib/diagram-theme"
 
 // --- Custom Nodes ---
 
@@ -174,9 +175,9 @@ const KnowledgeGraphCanvas = ({ projectId }: { projectId: string }) => {
                 target: e.targetId,
                 label: e.relation,
                 type: "smoothstep",
-                markerEnd: { type: MarkerType.ArrowClosed, color: "#64748b" },
-                style: { stroke: "#cbd5e1", strokeWidth: 1.5 },
-                labelStyle: { fontSize: 9, fill: "#64748b", fontWeight: 600 },
+                markerEnd: { type: MarkerType.ArrowClosed, color: DIAGRAM_EDGE_THEME.edgeStroke },
+                style: { stroke: DIAGRAM_EDGE_THEME.edgeStrokeLight, strokeWidth: 1.5 },
+                labelStyle: { fontSize: 9, fill: DIAGRAM_EDGE_THEME.edgeStroke, fontWeight: 600 },
                 animated: true,
             }))
 
@@ -218,7 +219,7 @@ const KnowledgeGraphCanvas = ({ projectId }: { projectId: string }) => {
                 fitView
                 nodesConnectable={false}
             >
-                <Background color="#cbd5e1" gap={20} />
+                <Background color={DIAGRAM_EDGE_THEME.gridDot} gap={20} />
                 <Controls />
                 <Panel position="top-right" className="bg-white/90 p-2 rounded-lg border shadow-sm flex gap-2">
                     <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => fetchGraph()}>

--- a/frontend/components/api-key-manager.tsx
+++ b/frontend/components/api-key-manager.tsx
@@ -6,8 +6,19 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Key, Trash2, Copy, Check, Plus, AlertCircle } from "lucide-react"
-import { formatDistanceToNow } from "date-fns"
+import { formatRelative } from "@/lib/format-date"
 import { toast } from "sonner"
 
 interface ApiKey {
@@ -199,23 +210,38 @@ export function ApiKeyManager() {
                                 {key.name}
                             </div>
                             <div className="text-xs text-muted-foreground flex items-center gap-4">
-                                <span>Created {formatDistanceToNow(new Date(key.createdAt))} ago</span>
+                                <span>Created {formatRelative(key.createdAt)}</span>
                                 <span>•</span>
-                                <span>Last used {formatDistanceToNow(new Date(key.lastUsed))} ago</span>
+                                <span>Last used {formatRelative(key.lastUsed)}</span>
                             </div>
                             <div className="text-xs font-mono text-muted-foreground">
                                 sra_live_...{key.id.slice(0, 4)}
                             </div>
                         </div>
-                        <Button
-                            variant="destructive"
-                            size="sm"
-                            className="w-full sm:w-auto rounded-full"
-                            onClick={() => revokeKey(key.id)}
-                        >
-                            <Trash2 className="h-4 w-4 mr-2" />
-                            Revoke
-                        </Button>
+                        <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                                <Button
+                                    variant="destructive"
+                                    size="sm"
+                                    className="w-full sm:w-auto rounded-full"
+                                >
+                                    <Trash2 className="h-4 w-4 mr-2" />
+                                    Revoke
+                                </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                                <AlertDialogHeader>
+                                    <AlertDialogTitle>Revoke &quot;{key.name}&quot;?</AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                        This takes effect immediately. Any script or CLI session using this key will stop working, and this cannot be undone.
+                                    </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                    <AlertDialogAction onClick={() => revokeKey(key.id)} className="bg-destructive hover:bg-destructive/90">Revoke</AlertDialogAction>
+                                </AlertDialogFooter>
+                            </AlertDialogContent>
+                        </AlertDialog>
                     </div>
                 ))}
             </div>

--- a/frontend/components/api-key-manager.tsx
+++ b/frontend/components/api-key-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { useAuth } from "@/lib/auth-context"
+import { useAuthFetch } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -31,6 +32,7 @@ interface ApiKey {
 
 export function ApiKeyManager() {
     const { token } = useAuth()
+    const authFetch = useAuthFetch()
     const [keys, setKeys] = useState<ApiKey[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [isCreateOpen, setIsCreateOpen] = useState(false)
@@ -40,9 +42,7 @@ export function ApiKeyManager() {
 
     const fetchKeys = useCallback(async () => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/keys`, {
-                headers: { Authorization: `Bearer ${token}` }
-            })
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/keys`)
             if (res.ok) {
                 const data = await res.json()
                 setKeys(data)
@@ -53,7 +53,7 @@ export function ApiKeyManager() {
         } finally {
             setIsLoading(false)
         }
-    }, [token])
+    }, [authFetch])
 
     useEffect(() => {
         if (token) {
@@ -65,12 +65,8 @@ export function ApiKeyManager() {
         if (!newKeyName.trim()) return
 
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/keys`, {
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/keys`, {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`
-                },
                 body: JSON.stringify({ name: newKeyName })
             })
 
@@ -90,9 +86,8 @@ export function ApiKeyManager() {
 
     const revokeKey = async (id: string) => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/keys/${id}`, {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` }
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/keys/${id}`, {
+                method: "DELETE"
             })
 
             if (res.ok) {

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -59,7 +59,7 @@ interface ProjectSummary {
 const layers = [
     { id: 1, label: "Structured Input", icon: FileText },
     { id: 2, label: "Validation Gate", icon: ShieldCheck },
-    { id: 3, label: "Final Analysis", icon: Bot },
+    { id: 3, label: "Drafting", icon: Bot },
     { id: 4, label: "Refinement", icon: Sparkles },
     { id: 5, label: "Knowledge Base", icon: Database },
 ] as const

--- a/frontend/components/diagram-editor.tsx
+++ b/frontend/components/diagram-editor.tsx
@@ -214,7 +214,7 @@ export function DiagramEditor({ title, initialCode, syntaxExplanation, onSave, o
                                                     </Button>
                                                 )}
                                             </div>
-                                            <div className="h-full border rounded-md overflow-hidden bg-white/50 dark:bg-black/20 p-4 relative flex-1 flex flex-col">
+                                            <div className="h-full border rounded-md overflow-hidden bg-white/50 p-4 relative flex-1 flex flex-col">
                                                 <div className="flex-1 overflow-auto flex items-center justify-center p-4 min-h-0">
                                                     <MermaidRenderer
                                                         chart={code}
@@ -226,7 +226,7 @@ export function DiagramEditor({ title, initialCode, syntaxExplanation, onSave, o
 
                                                 {/* Explicit Error Display */}
                                                 {lastError && (
-                                                    <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900 rounded text-xs text-red-600 dark:text-red-400 font-mono overflow-auto max-h-[100px] flex gap-2">
+                                                    <div className="mt-2 p-3 bg-red-50 border border-red-200 rounded text-xs text-red-600 font-mono overflow-auto max-h-[100px] flex gap-2">
                                                         <AlertTriangle className="h-4 w-4 shrink-0" />
                                                         <div className="flex-1">
                                                             <p className="font-bold mb-1">Syntax Error:</p>

--- a/frontend/components/markdown-display.tsx
+++ b/frontend/components/markdown-display.tsx
@@ -15,7 +15,7 @@ export const MarkdownDisplay = memo(function MarkdownDisplay({ content, classNam
     const Component = isInline ? 'span' : 'div';
 
     return (
-        <Component className={`prose prose-sm dark:prose-invert max-w-none ${isInline ? '!inline [&_*]:!inline [&_*]:!m-0 [&_*]:!p-0' : ''} ${className || ''}`}>
+        <Component className={`prose prose-sm max-w-none ${isInline ? '!inline [&_*]:!inline [&_*]:!m-0 [&_*]:!p-0' : ''} ${className || ''}`}>
             <Streamdown>
                 {content}
             </Streamdown>

--- a/frontend/components/provider-key-manager.tsx
+++ b/frontend/components/provider-key-manager.tsx
@@ -7,9 +7,21 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Sparkles, Trash2, Plus, CheckCircle2, Loader2, RefreshCw } from "lucide-react"
 import { toast } from "sonner"
 import type { DiscoveredModel } from "@/lib/models"
+import { extractErrorMessage } from "@/lib/api-response"
 
 export type AiProvider = "GEMINI" | "OPENAI" | "CLAUDE" | "GROK"
 
@@ -102,7 +114,7 @@ export function ProviderKeyManager() {
                 toast.success(`Key verified — ${models.length} model${models.length === 1 ? "" : "s"} available`)
             } else {
                 setVerifiedModels(null)
-                toast.error(json.message || json.error || "Key verification failed")
+                toast.error(extractErrorMessage(json, "Key verification failed"))
             }
         } catch {
             toast.error("Could not reach the verification service")
@@ -132,7 +144,7 @@ export function ProviderKeyManager() {
                     : `${PROVIDER_LABELS[provider]} key saved`)
                 closeDialog()
             } else {
-                toast.error(json.message || json.error || "Failed to save key")
+                toast.error(extractErrorMessage(json, "Failed to save key"))
             }
         } catch {
             toast.error("Error saving provider key")
@@ -158,7 +170,7 @@ export function ProviderKeyManager() {
                 const count = updated.availableModels?.length || 0
                 toast.success(`${PROVIDER_LABELS[p]}: ${count} model${count === 1 ? "" : "s"} available`)
             } else {
-                toast.error(json.message || json.error || "Could not refresh models")
+                toast.error(extractErrorMessage(json, "Could not refresh models"))
             }
         } catch {
             toast.error("Error refreshing models")
@@ -315,15 +327,30 @@ export function ProviderKeyManager() {
                                     : <RefreshCw className="h-4 w-4 mr-2" />}
                                 Refresh models
                             </Button>
-                            <Button
-                                variant="destructive"
-                                size="sm"
-                                className="flex-1 sm:flex-none rounded-full"
-                                onClick={() => removeKey(key.provider)}
-                            >
-                                <Trash2 className="h-4 w-4 mr-2" />
-                                Remove
-                            </Button>
+                            <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                    <Button
+                                        variant="destructive"
+                                        size="sm"
+                                        className="flex-1 sm:flex-none rounded-full"
+                                    >
+                                        <Trash2 className="h-4 w-4 mr-2" />
+                                        Remove
+                                    </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                    <AlertDialogHeader>
+                                        <AlertDialogTitle>Remove {PROVIDER_LABELS[key.provider]} key?</AlertDialogTitle>
+                                        <AlertDialogDescription>
+                                            This removes the stored key immediately. Any analysis configured to use {PROVIDER_LABELS[key.provider]} will need a different provider before it can generate again.
+                                        </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                        <AlertDialogAction onClick={() => removeKey(key.provider)} className="bg-destructive hover:bg-destructive/90">Remove</AlertDialogAction>
+                                    </AlertDialogFooter>
+                                </AlertDialogContent>
+                            </AlertDialog>
                         </div>
                     </div>
                 ))}

--- a/frontend/components/provider-key-manager.tsx
+++ b/frontend/components/provider-key-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { useAuth } from "@/lib/auth-context"
+import { useAuthFetch } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -47,6 +48,7 @@ const ALL_PROVIDERS: AiProvider[] = ["GEMINI", "OPENAI", "CLAUDE", "GROK"]
 
 export function ProviderKeyManager() {
     const { token } = useAuth()
+    const authFetch = useAuthFetch()
     const [keys, setKeys] = useState<ProviderKey[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [isAddOpen, setIsAddOpen] = useState(false)
@@ -60,9 +62,7 @@ export function ProviderKeyManager() {
 
     const fetchKeys = useCallback(async () => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys`, {
-                headers: { Authorization: `Bearer ${token}` }
-            })
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys`)
             if (res.ok) {
                 const json = await res.json()
                 setKeys(json.data || json)
@@ -73,7 +73,7 @@ export function ProviderKeyManager() {
         } finally {
             setIsLoading(false)
         }
-    }, [token])
+    }, [authFetch])
 
     useEffect(() => {
         if (token) {
@@ -102,9 +102,8 @@ export function ProviderKeyManager() {
         setIsVerifying(true)
         setVerifiedModels(null)
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys/verify`, {
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys/verify`, {
                 method: "POST",
-                headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
                 body: JSON.stringify({ provider, apiKey: apiKey.trim() })
             })
             const json = await res.json()
@@ -127,12 +126,8 @@ export function ProviderKeyManager() {
         if (!apiKey.trim()) return
         setIsSaving(true)
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys`, {
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys`, {
                 method: "PUT",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`
-                },
                 body: JSON.stringify({ provider, apiKey: apiKey.trim(), label: label.trim() || undefined })
             })
             const json = await res.json()
@@ -159,9 +154,8 @@ export function ProviderKeyManager() {
     const refreshModels = async (p: AiProvider) => {
         setRefreshing(p)
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys/${p}/refresh`, {
-                method: "POST",
-                headers: { Authorization: `Bearer ${token}` }
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys/${p}/refresh`, {
+                method: "POST"
             })
             const json = await res.json()
             if (res.ok) {
@@ -181,15 +175,15 @@ export function ProviderKeyManager() {
 
     const removeKey = async (p: AiProvider) => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys/${p}`, {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` }
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/settings/provider-keys/${p}`, {
+                method: "DELETE"
             })
             if (res.ok) {
                 setKeys(prev => prev.filter(k => k.provider !== p))
                 toast.success(`${PROVIDER_LABELS[p]} key removed`)
             } else {
-                toast.error("Failed to remove key")
+                const json = await res.json().catch(() => ({}))
+                toast.error(extractErrorMessage(json, "Failed to remove key"))
             }
         } catch {
             toast.error("Error removing provider key")

--- a/frontend/components/security-settings.tsx
+++ b/frontend/components/security-settings.tsx
@@ -2,8 +2,19 @@
 import { useState, useEffect, useCallback } from "react"
 import { useAuth } from "@/lib/auth-context"
 import { Button } from "@/components/ui/button"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Laptop, Smartphone, Globe, Clock, ShieldAlert } from "lucide-react"
-import { formatDistanceToNow } from "date-fns"
+import { formatRelative } from "@/lib/format-date"
 import { toast } from "sonner"
 import { UAParser } from "ua-parser-js"
 
@@ -129,7 +140,7 @@ export function SecuritySettings() {
                                     {session.isCurrent ? (
                                         <span className="text-green-600 font-medium">Active now</span>
                                     ) : (
-                                        <span>Last active {formatDistanceToNow(new Date(session.lastUsedAt))} ago</span>
+                                        <span>Last active {formatRelative(session.lastUsedAt)}</span>
                                     )}
                                 </div>
                                 <div className="text-xs text-muted-foreground truncate max-w-[200px] sm:max-w-[300px]">
@@ -137,14 +148,31 @@ export function SecuritySettings() {
                                 </div>
                             </div>
                         </div>
-                        <Button
-                            variant="destructive"
-                            size="sm"
-                            className="w-full sm:w-auto rounded-full"
-                            onClick={() => revokeSession(session.id)}
-                        >
-                            Revoke
-                        </Button>
+                        <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                                <Button
+                                    variant="destructive"
+                                    size="sm"
+                                    className="w-full sm:w-auto rounded-full"
+                                >
+                                    Revoke
+                                </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                                <AlertDialogHeader>
+                                    <AlertDialogTitle>Revoke this session?</AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                        {session.isCurrent
+                                            ? "This is your current session — revoking it will sign you out immediately."
+                                            : "That device will be signed out immediately and will need to log in again."}
+                                    </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                    <AlertDialogAction onClick={() => revokeSession(session.id)} className="bg-destructive hover:bg-destructive/90">Revoke</AlertDialogAction>
+                                </AlertDialogFooter>
+                            </AlertDialogContent>
+                        </AlertDialog>
                     </div>
                 ))}
             </div>

--- a/frontend/components/security-settings.tsx
+++ b/frontend/components/security-settings.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useState, useEffect, useCallback } from "react"
 import { useAuth } from "@/lib/auth-context"
+import { useAuthFetch } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
 import {
     AlertDialog,
@@ -30,15 +31,14 @@ interface Session {
 }
 
 export function SecuritySettings() {
-    const { token } = useAuth()
+    const { token, logout } = useAuth()
+    const authFetch = useAuthFetch()
     const [sessions, setSessions] = useState<Session[]>([])
     const [isLoading, setIsLoading] = useState(true)
 
     const fetchSessions = useCallback(async () => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/sessions`, {
-                headers: { Authorization: `Bearer ${token}` }
-            })
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/sessions`)
             if (res.ok) {
                 const data = await res.json()
                 setSessions(data)
@@ -48,7 +48,7 @@ export function SecuritySettings() {
         } finally {
             setIsLoading(false)
         }
-    }, [token])
+    }, [authFetch])
 
     useEffect(() => {
         let isMounted = true;
@@ -60,14 +60,21 @@ export function SecuritySettings() {
         return () => { isMounted = false; };
     }, [token, fetchSessions])
 
-    const revokeSession = async (sessionId: string) => {
+    const revokeSession = async (sessionId: string, isCurrent?: boolean) => {
         try {
-            const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/sessions/${sessionId}`, {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` }
+            const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/sessions/${sessionId}`, {
+                method: "DELETE"
             })
             if (res.ok) {
                 toast.success("Session revoked")
+                // Revoking the session you're on right now leaves the client holding a
+                // token the server no longer honors — clear local auth state and sign
+                // out instead of just dropping it from the list, matching what the
+                // confirm dialog told the user would happen.
+                if (isCurrent) {
+                    await logout()
+                    return
+                }
                 setSessions(prev => prev.filter(s => s.id !== sessionId))
             } else {
                 toast.error("Failed to revoke session")
@@ -169,7 +176,7 @@ export function SecuritySettings() {
                                 </AlertDialogHeader>
                                 <AlertDialogFooter>
                                     <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                    <AlertDialogAction onClick={() => revokeSession(session.id)} className="bg-destructive hover:bg-destructive/90">Revoke</AlertDialogAction>
+                                    <AlertDialogAction onClick={() => revokeSession(session.id, session.isCurrent)} className="bg-destructive hover:bg-destructive/90">Revoke</AlertDialogAction>
                                 </AlertDialogFooter>
                             </AlertDialogContent>
                         </AlertDialog>

--- a/frontend/components/ui/empty-state.tsx
+++ b/frontend/components/ui/empty-state.tsx
@@ -1,0 +1,31 @@
+import { LucideIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface EmptyStateProps {
+    icon: LucideIcon
+    heading: string
+    description?: string
+    cta?: { label: string; onClick: () => void }
+    /** Swaps the icon tile to the destructive palette for an error (vs. plain empty-list) state. */
+    variant?: "empty" | "error"
+}
+
+/** Shared "nothing to show" treatment — icon + heading + description + optional CTA. */
+export function EmptyState({ icon: Icon, heading, description, cta, variant = "empty" }: EmptyStateProps) {
+    return (
+        <div className="text-center py-12">
+            <div className={`inline-flex h-12 w-12 items-center justify-center rounded-full mb-4 ${variant === "error" ? "bg-destructive/10" : "bg-muted"}`}>
+                <Icon className={`h-6 w-6 ${variant === "error" ? "text-destructive" : "text-muted-foreground"}`} />
+            </div>
+            <h3 className="text-lg font-medium">{heading}</h3>
+            {description && (
+                <p className="text-muted-foreground mt-2 max-w-sm mx-auto">{description}</p>
+            )}
+            {cta && (
+                <Button onClick={cta.onClick} className="mt-5 gap-2 rounded-lg bg-foreground text-background hover:bg-foreground/90">
+                    {cta.label}
+                </Button>
+            )}
+        </div>
+    )
+}

--- a/frontend/components/version-diff-viewer.tsx
+++ b/frontend/components/version-diff-viewer.tsx
@@ -104,13 +104,13 @@ function DiffSection({ title, badge, children }: { title: string, badge?: string
 function DiffText({ oldText, newText }: { oldText: string, newText: string }) {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="p-4 rounded-xl border bg-red-50/30 dark:bg-red-950/10 border-red-200/50 dark:border-red-900/30">
+            <div className="p-4 rounded-xl border bg-red-50/30 border-red-200/50">
                 <div className="text-[10px] uppercase font-bold text-red-600 mb-2 flex items-center gap-2">
                     <div className="h-1.5 w-1.5 rounded-full bg-red-600" /> Previous
                 </div>
                 <div className="text-sm whitespace-pre-wrap break-words leading-relaxed opacity-70 italic">{oldText}</div>
             </div>
-            <div className="p-4 rounded-xl border bg-green-50/30 dark:bg-green-950/10 border-green-200/50 dark:border-green-900/30 shadow-sm">
+            <div className="p-4 rounded-xl border bg-green-50/30 border-green-200/50 shadow-sm">
                 <div className="text-[10px] uppercase font-bold text-green-600 mb-2 flex items-center gap-2">
                     <div className="h-1.5 w-1.5 rounded-full bg-green-600 animate-pulse" /> Updated
                 </div>

--- a/frontend/components/version-timeline.tsx
+++ b/frontend/components/version-timeline.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { format } from "date-fns"
+import { formatAbsolute } from "@/lib/format-date"
 import { useAuth } from "@/lib/auth-context"
 import { cn } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -161,7 +161,7 @@ export function VersionTimeline({ rootId, currentId, className, hideHeader = fal
                                     )}
 
                                     <span className="text-[10px] text-muted-foreground mt-1">
-                                        {format(new Date(version.createdAt), "MMM d, h:mm a")}
+                                        {formatAbsolute(version.createdAt)}
                                     </span>
 
                                     <div className="flex gap-2 mt-2">

--- a/frontend/lib/api-response.ts
+++ b/frontend/lib/api-response.ts
@@ -1,10 +1,25 @@
+/**
+ * Pulls a display message out of a parsed backend error body. `error` takes priority over
+ * `message` — matches errorMiddleware.js's response shape (`{ success, message, errorCode }`)
+ * and the `{ error }` shape used by a few older routes (e.g. repairDiagram) — so every call
+ * site reads the same field in the same order instead of each guessing its own priority.
+ */
+export function extractErrorMessage(body: unknown, fallback: string): string {
+    if (body && typeof body === "object") {
+        const b = body as Record<string, unknown>;
+        if (typeof b.error === "string" && b.error) return b.error;
+        if (typeof b.message === "string" && b.message) return b.message;
+    }
+    return fallback;
+}
+
 /** Throws with the backend's `{ error }`/`{ message }` body on a non-2xx response, falling back to statusText. */
 export async function handleResponse(res: Response): Promise<Response> {
     if (!res.ok) {
         let errorMessage = res.statusText;
         try {
             const errorData = await res.json();
-            errorMessage = errorData.error || errorData.message || res.statusText;
+            errorMessage = extractErrorMessage(errorData, res.statusText);
         } catch {
             // Ignore JSON parse error, fallback to statusText
         }

--- a/frontend/lib/diagram-theme.ts
+++ b/frontend/lib/diagram-theme.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared React Flow edge/grid styling for the DFD and knowledge-graph canvases
+ * (DFDViewer.tsx, knowledge-graph-tab.tsx). Both independently hardcoded the same slate
+ * palette — centralized here so the two diagrams can't silently drift apart. React Flow
+ * styles edges/markers via inline SVG attributes, which don't resolve CSS custom
+ * properties reliably across export (toPng) — so these stay literal hex rather than
+ * `var(--token)`, unlike the rest of the app's semantic-token styling.
+ */
+export const DIAGRAM_EDGE_THEME = {
+    arrowColor: '#334155',       // slate-700 — arrowhead marker
+    edgeStroke: '#64748b',       // slate-500 — default edge line
+    edgeStrokeLight: '#cbd5e1',  // slate-300 — lighter edge line (knowledge graph)
+    labelText: '#0f172a',        // slate-900 — edge label text
+    labelBackground: '#f8fafc',  // slate-50 — edge label background
+    gridDot: '#cbd5e1',          // slate-300 — canvas background grid dots
+    canvasExportBackground: '#ffffff', // flattened export background (toPng)
+} as const;

--- a/frontend/lib/format-date.ts
+++ b/frontend/lib/format-date.ts
@@ -1,0 +1,11 @@
+import { formatDistanceToNow, format } from "date-fns";
+
+/** "3 days ago" — the one relative-date convention used across the app. */
+export function formatRelative(date: string | Date): string {
+    return formatDistanceToNow(new Date(date), { addSuffix: true });
+}
+
+/** "Aug 21, 2026, 3:45 PM" — the one absolute-date convention used across the app. */
+export function formatAbsolute(date: string | Date): string {
+    return format(new Date(date), "MMM d, yyyy, h:mm a");
+}


### PR DESCRIPTION
## Summary

**Backend — error handling and provider resilience**
- New `errorSanitizer.js`: a single choke point that turns any error reaching an HTTP response, SSE frame, or persisted `Analysis.metadata` field into a safe, informative-but-provider-agnostic message (names the provider when known, never raw SDK text/stacks/JSON). Replaces ad hoc regex classifiers in `validateAnalysis`/`repairDiagram` and the raw `error.message` passthroughs in `analysisService.js`, `chatStream`, and `errorMiddleware.js`.
- `BaseAgent.callLLM` now falls back to the user's next BYOK-approved provider on overload/5xx (immediately, skipping wasted same-provider retries), auth errors, and exhausted rate-limit retries — scoped per agent instance, so a `DeveloperAgent` making several sectional calls only rediscovers a dead provider once, not on every call. Single-key users see no behavior change.
- Two bugs fixed along the way: `modelFallbackService.selectNextFallbackModel` was dropping the resolved `apiKey` from its return (fallback would have had no usable key), and `chatService.resolveChatProvider` was dropping `userId` entirely (silently broke quota tracking and made chat fallback impossible).

**Frontend — UI consistency pass** (from a first-time-user audit)
- Fixed a real bug: a failed analysis-history fetch was rendering as "No analyses yet" instead of an error state.
- Chat's "I've drafted your IEEE-830 SRS" message is now format-aware (was wrong for Volere/ISO/Agile PRD analyses).
- Added confirm dialogs to four destructive one-click actions that had none: provider key removal, API key revocation, and session revocation (project/account deletion already had this pattern).
- Consolidated 5 different date-formatting conventions, 3 different empty-state treatments, and inconsistent terminology/branding into shared helpers (`lib/format-date.ts`, `components/ui/empty-state.tsx`).
- Removed `dark:` Tailwind variants and centralized diagram-canvas hex colors, per the project's light-only design-token convention.

## Test plan
- [x] `pnpm --filter backend test` — 502/502 passing (17 new tests across fallback/sanitizer/middleware, 1 updated)
- [x] `pnpm --filter @sra-srs/sra-cli test` — 58/58 passing
- [x] `pnpm --filter frontend test` — 89/89 passing
- [x] `pnpm run lint:all` — 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback models for supported AI requests.
  * Added confirmation dialogs before removing provider/API keys or revoking sessions.
  * Added clearer empty states, retry actions, and analysis error notifications.
* **Bug Fixes**
  * Improved error messages while hiding sensitive provider and system details.
  * Standardized date and timestamp displays across the app.
* **Style**
  * Updated branding, labels, titles, diagram colors, and light-theme presentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->